### PR TITLE
DMF-5506 Fix fixture timeout

### DIFF
--- a/src/support/fixture.ts
+++ b/src/support/fixture.ts
@@ -16,7 +16,7 @@ export const fixture = function(originalCommand: ((...args: any[]) => any), fixt
             }
 
             try {
-                cy.readFile('./node_modules/@jahia/cypress/fixtures/' + fixture, encoding, {log: false, timeout: 0})
+                cy.readFile('./node_modules/@jahia/cypress/fixtures/' + fixture, encoding, {log: false, timeout: 200})
             } catch (e) {
                 console.log(e)
             }


### PR DESCRIPTION
In some Cypress versions/environments, the 0ms timeout is causing problems because it actually performs an HTTP request to read the file. Increasing the timeout to 200ms seems like a good balance between a reasonable timeout and still good performance in case the file doesn't exist.
