### PR TITLE
Add error handling to prevent tests from breaking when API requests t…

### DIFF
--- a/src/support/apollo/apollo.ts
+++ b/src/support/apollo/apollo.ts
@@ -70,7 +70,13 @@ export const apollo = function (apollo: ApolloClient<any>, options: ApolloOption
             }
 
             cy.wrap({}, {log: false})
-                .then(() => (isQuery(options) ? apollo.query(options) : apollo.mutate(options))
+                .then(() => (isQuery(options) ? apollo.query(options).catch(error => {
+                        cy.log(`Caught Graphql Query Error: ${JSON.stringify(error)}`);
+                        return error;
+                    }) : apollo.mutate(options).catch(error => {
+                        cy.log(`Caught Graphql Mutation Error: ${JSON.stringify(error)}`);
+                        return error;
+                    }))
                     .then(r => {
                         result = r
                         logger?.end()


### PR DESCRIPTION
When there is an error (path not found, item exists etc.) apollo throws an exception and since Cypress by design doesn't allow use of try catch the test breaks. The problem is that I might expect there to be an error as in the case when something was created in test body, the test broke and whatever was created never got leaned up at the end of test and I enter the test again. In a case like that I either need to guarantee fresh env. all the time or handle potential "loose" artifacts from previous run. I can't handle them now because a request to remove or get something that doesn't exist results in an error.  