### PR TITLE
BACKLOG-20097 add timeout on runProvisioningScript

### DIFF
--- a/src/support/provisioning/runProvisioningScript.ts
+++ b/src/support/provisioning/runProvisioningScript.ts
@@ -103,7 +103,7 @@ export const runProvisioningScript = (script: FormFile | StringDictionary[], fil
         })
     }
 
-    let request = {
+    const request = {
         url: `${jahiaServer.url}/modules/api/provisioning`,
         method: 'POST',
         auth: {
@@ -115,7 +115,7 @@ export const runProvisioningScript = (script: FormFile | StringDictionary[], fil
         log: false
     }
 
-    if(typeof timeout !== undefined){
+    if(typeof timeout !== 'undefined'){
         request.timeout = timeout
     }
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20097

## Description

Add timeout on runProvidingScript to allow use of bigger providing scripts

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->


