### PR TITLE
DMF-6188: Added a utility function to get Jahia version

### DIFF
--- a/fixtures/graphql/jcr/query/getJahiaVersion.graphql
+++ b/fixtures/graphql/jcr/query/getJahiaVersion.graphql
@@ -1,0 +1,12 @@
+query {
+    admin {
+        jahia {
+            version {
+              release
+              build
+              buildDate
+              isSnapshot
+            }
+        }
+    }
+}

--- a/src/utils/JahiaPlatformHelper.ts
+++ b/src/utils/JahiaPlatformHelper.ts
@@ -1,0 +1,8 @@
+export const getJahiaVersion = (): Cypress.Chainable => {
+    return cy.apollo({
+        fetchPolicy: 'no-cache',
+        queryFile: 'graphql/jcr/query/getJahiaVersion.graphql'
+    }).then(result => {
+        return result?.data?.admin.jahia.version;
+    })
+};

--- a/src/utils/JahiaPlatformHelper.ts
+++ b/src/utils/JahiaPlatformHelper.ts
@@ -4,5 +4,5 @@ export const getJahiaVersion = (): Cypress.Chainable => {
         queryFile: 'graphql/jcr/query/getJahiaVersion.graphql'
     }).then(result => {
         return result?.data?.admin.jahia.version;
-    })
+    });
 };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,3 +4,4 @@ export * from './SiteHelper';
 export * from './UsersHelper';
 export * from './VanityUrlHelper';
 export * from './ClusterHelper';
+export * from './JahiaPlatformHelper';


### PR DESCRIPTION
The goal here is to be able to skip entire test suites if they are not meeting the right version conditions (version check to be performed in the corresponding project).