### PR TITLE
BACKLOG-21359: Add disable module helper

### DIFF
--- a/fixtures/graphql/jcr/mutation/disableModule.graphql
+++ b/fixtures/graphql/jcr/mutation/disableModule.graphql
@@ -1,0 +1,9 @@
+mutation disableModule($moduleName: String!, $pathOrId: String!) {
+  jcr {
+    mutateNode(pathOrId: $pathOrId) {
+      mutateProperty(name: "j:installedModules") {
+        removeValue(value: $moduleName)
+      }
+    }
+  }
+}

--- a/src/utils/SiteHelper.ts
+++ b/src/utils/SiteHelper.ts
@@ -22,6 +22,13 @@ export const enableModule = (moduleName: string, siteKey: string): void => {
     });
 };
 
+export const disableModule = (moduleName: string, siteKey: string): void => {
+    cy.apollo({
+        mutationFile: 'graphql/jcr/mutation/disableModule.graphql',
+        variables: {moduleName, pathOrId: `/sites/${siteKey}`}
+    });
+};
+
 export const editSite = (siteKey: string, config: {serverName: string} = {serverName: 'localhost'}): void => {
     cy.executeGroovy('groovy/admin/editSite.groovy', {
         SITEKEY: siteKey,


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-21359

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Add helper function for disabling modules for a given site.

We do not have the same provisioning function for disabling modules like we do for `enableModule()`; use graphql instead