### PR TITLE
TECH-1631: Better identification of types and include deprecations

### DIFF
--- a/fixtures/graphql/introspection.graphql
+++ b/fixtures/graphql/introspection.graphql
@@ -20,15 +20,27 @@ query IntrospectionQuery($typeName: String!) {
                 kind
                 name
                 description
+                ofType {
+                    name
+                    description
+                }
             }
         }
         interfaces {
             name
             description
+            ofType {
+                name
+                description
+            }            
         }
         possibleTypes {
             name
             description
+            ofType {
+                name
+                description
+            }            
         }
         enumValues(includeDeprecated: true) {
             name
@@ -43,11 +55,19 @@ query IntrospectionQuery($typeName: String!) {
                 kind
                 name
                 description
+                ofType {
+                    name
+                    description
+                }                
             }
         }
         ofType {
             name
             description
+            ofType {
+                name
+                description
+            }            
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jahia/cypress",
-  "version": "3.17.8",
+  "version": "3.17.9",
   "scripts": {
     "build": "tsc",
     "lint": "eslint src -c .eslintrc.json --ext .ts"


### PR DESCRIPTION
In some situations, the type name is present in ofType.name (instead of name directly). Whenever a type is processed, its "ofType" is then also added.

Also added deprecation messages directly into the descriptions object, to be checked by the tests.