### PR TITLE
TECH-1635 Yarn v4 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ node_modules
 .idea
 *.iml
 .DS_Store
+.env
+.yarn/cache
+.yarn/unplugged
+.yarn/build-state.yml
+.yarn/install-state.gz

--- a/ci.build.sh
+++ b/ci.build.sh
@@ -39,6 +39,6 @@ if [ -d ./jahia-module ]; then
   fi
   cd ..
 fi
+YARN_VERSION=${YARN_VERSION:-1.22.22}
 
-
-docker build -f $BASEDIR/env.Dockerfile -t ${TESTS_IMAGE} .
+docker build --build-arg YARN_VERSION=${YARN_VERSION} -f $BASEDIR/env.Dockerfile -t ${TESTS_IMAGE} .

--- a/env.Dockerfile
+++ b/env.Dockerfile
@@ -2,25 +2,26 @@ FROM cypress/browsers:node-20.10.0-chrome-118.0.5993.88-1-ff-118.0.2-edge-118.0.
 
 ARG MAVEN_VER="3.8.1"
 ARG MAVEN_BASE_URL="https://archive.apache.org/dist/maven/maven-3"
+ARG YARN_VERSION="1.22.22"
 
-RUN apt-get update && apt-get install -y jq curl
-
-RUN adduser --disabled-password jahians
+RUN apt-get update && apt-get install -y jq curl ; \
+    adduser --disabled-password jahians ; \
+    mkdir -p /home/jahians/run-artifacts /home/jahians/results /home/jahians/cypress/plugins; \
+    npm install -g corepack ; \
+    corepack enable
 
 USER jahians
 WORKDIR /home/jahians
 
-COPY --chown=jahians:jahians package.json yarn.lock /home/jahians/
-
-RUN mkdir -p /home/jahians/run-artifacts /home/jahians/results /home/jahians/cypress/plugins
-
-#CI=true reduces the verbosity of the installation logs
-RUN CI=true yarn install --non-interactive
-
 COPY --chown=jahians:jahians . /home/jahians
 
-RUN CI=true /home/jahians/node_modules/.bin/cypress install
-
-RUN mkdir -p .m2; cp maven.settings.xml .m2/settings.xml; exit 0
+#CI=true reduces the verbosity of the installation logs
+RUN CI=true yarn set version ${YARN_VERSION} \
+    CI=true yarn install; \
+    ls -al /home/jahians/ ; \
+    /home/jahians/node_modules/.bin/cypress install; \
+    mkdir -p .m2; \
+    cp maven.settings.xml .m2/settings.xml; \
+    exit 0
 
 CMD /bin/bash -c /home/jahians/env.run.sh

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jahia/cypress",
-  "version": "3.18.1",
+  "version": "3.19.0",
   "scripts": {
     "build": "tsc",
     "lint": "eslint src -c .eslintrc.json --ext .ts"


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/TECH-1635

## Description

- Make it possible to use Yarn v4 when generating test images
- Optimize the generated Docker image to reduce the number of generating layers by regrouping all the commands that can be regrouped.
- Please note these changes were tested locally on this project with Yarn v1.2.22 and Yarn v4.1.1 but due to the nature of how tests projects are generated with the scripts in library true validation can only happen once we can integrate with the projects using these scripts.
