### PR TITLE
TECH-654 - added workspace argument to deleteNode

### DIFF
--- a/fixtures/graphql/jcr/mutation/deleteNode.graphql
+++ b/fixtures/graphql/jcr/mutation/deleteNode.graphql
@@ -1,5 +1,5 @@
-mutation deleteNode($pathOrId: String!) {
-    jcr(workspace: EDIT) {
+mutation deleteNode($pathOrId: String!, $workspace: Workspace!) {
+    jcr(workspace: $workspace) {
         deleteNode(pathOrId: $pathOrId)
     }
 }

--- a/src/utils/JCRHelper.ts
+++ b/src/utils/JCRHelper.ts
@@ -1,3 +1,5 @@
+type Workspace = 'EDIT' | 'LIVE';
+
 export const setNodeProperty = (pathOrId: string, property: string, value: string | Array<string>, language: string): Cypress.Chainable => {
     let mutationFile = 'graphql/jcr/mutation/setProperty.graphql';
     if (value instanceof Array) {
@@ -15,10 +17,11 @@ export const setNodeProperty = (pathOrId: string, property: string, value: strin
     });
 };
 
-export const deleteNode = (pathOrId: string): Cypress.Chainable => {
+export const deleteNode = (pathOrId: string, workspace: Workspace = 'EDIT'): Cypress.Chainable => {
     return cy.apollo({
         variables: {
-            pathOrId: pathOrId
+            pathOrId: pathOrId,
+            workspace
         },
         mutationFile: 'graphql/jcr/mutation/deleteNode.graphql'
     });
@@ -43,7 +46,7 @@ export const addNode = (variables: { parentPathOrId: string, primaryNodeType: st
     });
 };
 
-export const getNodeByPath = (path: string, properties?: string[], language?: string, childrenTypes: string[] = [], workspace: 'EDIT' | 'LIVE' = 'EDIT'): Cypress.Chainable => {
+export const getNodeByPath = (path: string, properties?: string[], language?: string, childrenTypes: string[] = [], workspace: Workspace = 'EDIT'): Cypress.Chainable => {
     return cy.apollo({
         variables: {
             path: path,


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/TECH-654

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

This PR adds the `workspace` argument to `deleteNode` utility, so we can delete nodes in any workspace.

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [x] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [x] Performance
- [x] Migration
- [x] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
