### PR TITLE
Ease debugging by displaying a portion of the NEXUS_USERNAME variable

### DIFF
--- a/ci.startup.sh
+++ b/ci.startup.sh
@@ -12,6 +12,7 @@ echo " MANIFEST: ${MANIFEST}"
 echo " TESTS_IMAGE: ${TESTS_IMAGE}"
 echo " JAHIA_IMAGE: ${JAHIA_IMAGE}"
 echo " JAHIA_CLUSTER_ENABLED: ${JAHIA_CLUSTER_ENABLED}"
+echo " NEXUS_USERNAME: ${NEXUS_USERNAME:0:3}***${NEXUS_USERNAME:(-6)}"
 
 echo "$(date +'%d %B %Y - %k:%M') [LICENSE] == Check if license exists in env variable (JAHIA_LICENSE) =="
 if [[ -z ${JAHIA_LICENSE} ]]; then

--- a/env.provision.sh
+++ b/env.provision.sh
@@ -11,6 +11,7 @@ START_TIME=$SECONDS
 
 echo "$(date +'%d %B %Y - %k:%M') == Printing the most important environment variables"
 echo " MANIFEST: ${MANIFEST}"
+echo " NEXUS_USERNAME: ${NEXUS_USERNAME:0:3}***${NEXUS_USERNAME:(-6)}"
 echo " TESTS_IMAGE: ${TESTS_IMAGE}"
 echo " JAHIA_IMAGE: ${JAHIA_IMAGE}"
 echo " JAHIA_CLUSTER_ENABLED: ${JAHIA_CLUSTER_ENABLED}"

--- a/env.run.sh
+++ b/env.run.sh
@@ -8,6 +8,9 @@ bash $BASEDIR/env.provision.sh
 
 source $BASEDIR/set-env.sh
 
+echo "$(date +'%d %B %Y - %k:%M') == env.run.sh == Printing the most important environment variables"
+echo "$(date +'%d %B %Y - %k:%M') == NEXUS_USERNAME: ${NEXUS_USERNAME:0:3}***${NEXUS_USERNAME:(-6)}"
+
 echo "$(date +'%d %B %Y - %k:%M') == Fetching the list of installed modules =="
 bash -c "unset npm_config_package; npx --yes @jahia/jahia-reporter@latest utils:modules \
   --moduleId=\"${MODULE_ID}\" \

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jahia/cypress",
-  "version": "3.22.0",
+  "version": "3.23.0",
   "scripts": {
     "build": "tsc",
     "lint": "eslint src -c .eslintrc.json --ext .ts"


### PR DESCRIPTION
When provisioning Jahia with artifacts requiring authentication, it can be useful to verify that the necessary environment variables are passed:
- Display only a portion of the username
- To not log the password but assume instead that if username is passed properly, same goes for username

Note: It is likely that in GitHub Actions, the username will be obfuscated entirely anyway, but this will help confirm whether a username is passed (obfuscated data) or none (empty string)