### PR TITLE
TECH-1988: Fix missing node-ssh dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jahia/cypress",
-  "version": "3.27.0",
+  "version": "3.28.0",
   "scripts": {
     "build": "tsc",
     "lint": "eslint src -c .eslintrc.json --ext .ts"
@@ -26,14 +26,14 @@
     "eslint-plugin-jest": "^27.2.1",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "node-ssh": "^13.2.0",
     "typescript": "^4.3.5"
   },
   "dependencies": {
     "@apollo/client": "^3.4.9",
     "cypress-real-events": "^1.11.0",
     "graphql": "^15.5.0",
-    "graphql-tag": "^2.11.0"
+    "graphql-tag": "^2.11.0",
+    "node-ssh": "^13.2.0"
   },
   "packageManager": "yarn@4.5.0"
 }


### PR DESCRIPTION
node-ssh was declared as devDependency when it should be a regular dependency

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/TECH-1988

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Move the 'node-ssh' dependency from the `devDependencies` section to the `dependencies` one as it's required at runtime.

