### PR TITLE
BACKLOG-23323 Reverting changes to the getJobsWithStatus query

### DIFF
--- a/fixtures/graphql/jcr/query/getJobsWithStatus.graphql
+++ b/fixtures/graphql/jcr/query/getJobsWithStatus.graphql
@@ -3,11 +3,9 @@ query getJobsWithStatus{
         jahia {
             scheduler{
                 jobs {
-                    nodes {
-                        siteKey
-                        group
-                        jobStatus
-                    }
+                    siteKey
+                    group
+                    jobStatus
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jahia/cypress",
-  "version": "3.34.0",
+  "version": "3.35.0",
   "scripts": {
     "build": "tsc",
     "lint": "eslint src -c .eslintrc.json --ext .ts"

--- a/schema.graphql
+++ b/schema.graphql
@@ -1065,6 +1065,18 @@ type GqlBackgroundJobEdge {
     node: GqlBackgroundJob
 }
 
+"Channel information"
+type GqlChannel {
+    "Channel label (not localized)"
+    displayName: String
+    "Return true if channel is visible, otherwise false"
+    isVisible: Boolean
+    "Channel name/identifier"
+    name: String
+    "Return variants for this channel, if available"
+    variants: [GqlVariant]
+}
+
 "Condition for override item"
 type GqlCondition {
     "Item will apply only on this nodetype"
@@ -1365,6 +1377,8 @@ type GqlHealthCheck {
 
 "jContent API"
 type GqlJContent {
+    "Returns all available channels"
+    channels: [GqlChannel]
     "Returns html with marked differences"
     diffHtml(
         "New html"
@@ -1654,8 +1668,10 @@ type GqlPublicationInfo {
 
 "Scheduler object which allows to access to background jobs"
 type GqlScheduler {
-    "List of active jobs"
-    jobs(
+    "List of active jobs (deprecated)"
+    jobs: [GqlBackgroundJob] @deprecated(reason: "Use paginatedJobs instead")
+    "List of active jobs (paginated)"
+    paginatedJobs(
         "fetching only nodes after this node (exclusive)"
         after: String,
         "fetching only nodes before this node (exclusive)"
@@ -1683,6 +1699,24 @@ type GqlScope {
     description: String
     "The name of the scope"
     name: String
+}
+
+"Variant information for a given channel"
+type GqlVariant {
+    "Variant display name/label (not localized)"
+    displayName: String
+    "Variant dimension (width x height) if available"
+    imageSize: GqlVariantDimension
+    "Variant name/identifier"
+    name: String
+}
+
+"Represents dimensions (width, height) of a variant"
+type GqlVariantDimension {
+    "Variant height"
+    height: String
+    "Variant width"
+    width: String
 }
 
 type GqlWorkflowEvent {

--- a/src/utils/PublicationAndWorkflowHelper.ts
+++ b/src/utils/PublicationAndWorkflowHelper.ts
@@ -51,7 +51,7 @@ export const waitAllJobsFinished = (errorMessage?: string, timeout = 60000): voi
                     queryFile: 'graphql/jcr/query/getJobsWithStatus.graphql'
                 })
                 .then(response => {
-                    const jobs = response?.data?.admin?.jahia?.scheduler?.jobs.nodes;
+                    const jobs = response?.data?.admin?.jahia?.scheduler?.jobs;
                     const publicationJobs = jobs.filter(job => job.group === 'PublicationJob');
                     const hasActivePublicationJobs = publicationJobs.some(job => job.jobStatus === 'EXECUTING');
                     return !hasActivePublicationJobs;


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
This PR reverts the change to the `getJobsWithStatus` query after the change in GQL API was reverted.

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
