### PR TITLE
QABACKLOG-1661: Upgraded cypress base image

### DIFF
--- a/env.Dockerfile
+++ b/env.Dockerfile
@@ -1,4 +1,4 @@
-FROM cypress/browsers:node-20.10.0-chrome-118.0.5993.88-1-ff-118.0.2-edge-118.0.2088.46-1
+FROM cypress/browsers:node-22.13.1-chrome-132.0.6834.159-1-ff-134.0.2-edge-132.0.2957.127-1
 
 ARG MAVEN_VER="3.8.1"
 ARG MAVEN_BASE_URL="https://archive.apache.org/dist/maven/maven-3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jahia/cypress",
-  "version": "3.35.0",
+  "version": "4.0.0",
   "scripts": {
     "build": "tsc",
     "lint": "eslint src -c .eslintrc.json --ext .ts"


### PR DESCRIPTION
https://jira.jahia.org/browse/QABACKLOG-1661

I built the image locally to verify that indeed the error is not present anymore:
```
#6 3.436 W: GPG error: https://dl.google.com/linux/chrome/deb stable InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 32EE5355A6BC6E42
```

This does not guarantee that all codebases consuming jahia/cypress will be compatible with this new base image, but this will have to be handled codebase by codebase (and it's also likely that it will be compatible).