### PR TITLE
feat: add shouldNotHaveRoleItem; refactor Menu functions

### DIFF
--- a/src/page-object/moonstone/menu.ts
+++ b/src/page-object/moonstone/menu.ts
@@ -7,34 +7,45 @@ export class Menu extends BaseComponent {
     static overlaySelector = '.moonstone-menu_overlay';
 
     submenu(item: string, menu: string): Menu {
-        this.get().find('.moonstone-menuItem').contains(item).scrollIntoView().should('be.visible');
+        this.shouldHaveItem(item);
         this.get().find('.moonstone-menuItem').contains(item).realHover();
         return getComponentByRole(Menu, menu);
     }
 
     shouldHaveItem(item: string):void {
-        this.get().find('.moonstone-menuItem').contains(item).scrollIntoView().should('be.visible');
+        this.get().find('.moonstone-menuItem').contains(item).scrollIntoView();
+        this.get().find('.moonstone-menuItem').contains(item).should('be.visible');
+    }
+
+    shouldHaveRoleItem(role: string):void {
+        this.get().find(`.moonstone-menuItem[data-sel-role=${role}]`).scrollIntoView();
+        this.get().find(`.moonstone-menuItem[data-sel-role=${role}]`).should('be.visible');
     }
 
     shouldNotHaveItem(item: string):void {
         this.get().find('.moonstone-menuItem').contains(item).should('not.exist');
     }
 
+    shouldNotHaveRoleItem(role: string):void {
+        this.get().find(`.moonstone-menuItem[data-sel-role="${role}"]`).should('not.exist');
+    }
+
     select(item: string): Menu {
-        this.get().find('.moonstone-menuItem').contains(item).scrollIntoView().should('be.visible');
+        this.shouldHaveItem(item);
         this.get().find('.moonstone-menuItem').contains(item).trigger('click');
         return this;
     }
 
-    selectByRole(item: string): Menu {
-        this.get().find(`.moonstone-menuItem[data-sel-role="${item}"]`).scrollIntoView().should('be.visible');
-        this.get().find(`.moonstone-menuItem[data-sel-role="${item}"]`).trigger('click');
+    selectByRole(role: string): Menu {
+        this.shouldHaveRoleItem(role);
+        this.get().find(`.moonstone-menuItem[data-sel-role="${role}"]`).trigger('click');
         return this;
     }
 
     /** Can be used for choicelist dropdown menu */
     selectByValue(value: string): Menu {
-        this.get().find(`.moonstone-menuItem[data-value="${value}"]`).scrollIntoView().should('be.visible');
+        this.get().find(`.moonstone-menuItem[data-value="${value}"]`).scrollIntoView();
+        this.get().find(`.moonstone-menuItem[data-value="${value}"]`).should('be.visible');
         this.get().find(`.moonstone-menuItem[data-value="${value}"]`).trigger('click');
         return this;
     }


### PR DESCRIPTION
- add `shouldHaveRoleItem`, `shouldNotHaveRoleItem` for validating using role selector
- refactor some validation functions
- split calls `scrollIntoView` and `should` as it's not suppose to be chainable