### PR TITLE
fix: fixed use jahia cluster profile in docker-compose when starting the environment

### DIFF
--- a/ci.startup.sh
+++ b/ci.startup.sh
@@ -27,12 +27,12 @@ if [[ -z ${JAHIA_LICENSE} ]]; then
 fi
 
 echo "$(date +'%d %B %Y - %k:%M') == Cluster enabled: ${JAHIA_CLUSTER_ENABLED} =="
-if [[ "${JAHIA_CLUSTER_ENABLED}" == "true" ]]; then
+if [[ "${JAHIA_CLUSTER_ENABLED}" == "true" ||  ${JAHIA_CLUSTER_ENABLED} == true ]]; then
     export CLUSTER_PROFILE="--profile cluster"
 fi
 
 echo "$(date +'%d %B %Y - %k:%M') == Starting environment =="
-docker-compose up -d --renew-anon-volumes ${CLUSTER_PROFILE}
+docker-compose ${CLUSTER_PROFILE} up -d --renew-anon-volumes
 if [[ "$1" != "notests" ]]; then
     docker ps -a
     docker stats --no-stream


### PR DESCRIPTION
Fixed the possibility to start a cluster. When  "--profile cluster" is at the end of the docker-compose command the non processing nodes jahia-browsing-a and jahia-browsing-b are not started only jahia, mariadb and cypress starts. When i set the parameter at the beginning of the command the cluster and the standalone mode can both be started as expected. Also in the documentation examples this parameter is setted at the begining https://docs.docker.com/compose/how-tos/profiles/

Also handled the variable format to be able the handle both string and boolean for JAHIA_CLUSTER_ENABLED variable as it can be different from one code base to another