### PR TITLE
feat: add remember me option to login function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jahia/cypress",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "scripts": {
     "build": "tsc",
     "lint": "eslint src -c .eslintrc.json --ext .ts --max-warnings=0"

--- a/src/support/login.ts
+++ b/src/support/login.ts
@@ -7,13 +7,14 @@ declare global {
     namespace Cypress {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         interface Chainable<Subject> {
-            login(username?: string, password?: string, url?: string): Chainable<Cypress.Response<any>>
+            login(username?: string, password?: string, config?: string| {url?: string; rememberMe?: boolean}): Chainable<Cypress.Response<any>>
             loginAndStoreSession(username?: string, password?: string, url?: string): Chainable<Cypress.Response<any>>
         }
     }
 }
-
-export const login = (username = 'root', password: string = Cypress.env('SUPER_USER_PASSWORD'), url = '/cms/login'): void => {
+// Disable linter to keep as this for backward compatibility
+// eslint-disable-next-line default-param-last
+export const login = (username = 'root', password: string = Cypress.env('SUPER_USER_PASSWORD'), config: string | { url?: string, rememberMe?: boolean }): void => {
     Cypress.log({
         name: 'login',
         message: `Login with ${username}`,
@@ -23,11 +24,22 @@ export const login = (username = 'root', password: string = Cypress.env('SUPER_U
             };
         }
     });
+    const body: {username: string, password: string, useCookie?: string} = {username, password};
+    let url = '/cms/login';
+    if (typeof config === 'object') {
+        if (config.rememberMe) {
+            body.useCookie = 'on';
+        }
+
+        url = config.url ?? url;
+    } else {
+        url = config ?? url;
+    }
 
     cy.request({
         method: 'POST',
         form: true,
-        body: {username, password},
+        body,
         followRedirect: false,
         log: false,
         url


### PR DESCRIPTION
Now login function is
```
login(username?: string, password?: string, config?: string| {url?: string; rememberMe?: boolean})

```

Other parameters than login/password are provided as an object. It is backward compatible with the previous version (with `url` as last parameter)
