### PR TITLE
feat: add cy.step command

### DIFF
--- a/src/support/index.ts
+++ b/src/support/index.ts
@@ -3,3 +3,4 @@ export * from './provisioning';
 export * from './login';
 export * from './logout';
 export * from './repeatUntil';
+export * from './testStep';

--- a/src/support/registerSupport.ts
+++ b/src/support/registerSupport.ts
@@ -4,6 +4,7 @@ import {login, loginAndStoreSession} from './login';
 import {logout} from './logout';
 import {fixture} from './fixture';
 import {repeatUntil} from './repeatUntil';
+import {step} from './testStep';
 
 export const registerSupport = (): void => {
     Cypress.Commands.add('apolloClient', apolloClient);
@@ -19,4 +20,6 @@ export const registerSupport = (): void => {
     Cypress.Commands.add('repeatUntil', repeatUntil);
 
     Cypress.Commands.overwrite('fixture', fixture);
+
+    Cypress.Commands.add('step', step);
 };

--- a/src/support/testStep.ts
+++ b/src/support/testStep.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment*/
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 /**
  *  Extends global Cypress Chainable interface with custom commands from 'commands.js' to avoid TypeScript errors when using them.
  */

--- a/src/support/testStep.ts
+++ b/src/support/testStep.ts
@@ -1,0 +1,40 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-namespace */
+/**
+ *  Extends global Cypress Chainable interface with custom commands from 'commands.js' to avoid TypeScript errors when using them.
+ */
+declare global {
+    // eslint-disable-next-line @typescript-eslint/no-namespace
+    namespace Cypress {
+        interface Chainable<Subject> {
+            /**
+             * Creates a foldable test-case step with corresponding message in Cypress log
+             * @param {string} message - folder's message
+             * @param {() => void} func - function to be executed and wrapped into the folder
+             * @returns void
+             * @example
+             *         cy.step('Navigate to the destination point', () => {
+             *              cy.get('selector').click();
+             *              ...
+             *         });
+             *
+             *        cy.step('Do something', () => {
+             *              cy.get('element').click();
+             *              ...
+             *         });
+             */
+            step (message: string, func: () => void): void;
+        }
+    }
+}
+
+export const step = (message: string, func: () => void): void => {
+    cy.then(() => {
+        //@ts-ignore
+        Cypress.log({groupStart: true, displayName: '[ STEP ]', message: `${message}`});
+    }).then(() => {
+        func();
+    }).then(() => {
+        //@ts-ignore
+        Cypress.log({groupEnd: true, emitOnly: true});
+    });
+};

--- a/src/support/testStep.ts
+++ b/src/support/testStep.ts
@@ -5,6 +5,7 @@
 declare global {
     // eslint-disable-next-line @typescript-eslint/no-namespace
     namespace Cypress {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         interface Chainable<Subject> {
             /**
              * Creates a foldable test-case step with corresponding message in Cypress log

--- a/src/support/testStep.ts
+++ b/src/support/testStep.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-namespace */
+/* eslint-disable @typescript-eslint/ban-ts-comment*/
 /**
  *  Extends global Cypress Chainable interface with custom commands from 'commands.js' to avoid TypeScript errors when using them.
  */
@@ -29,12 +29,12 @@ declare global {
 
 export const step = (message: string, func: () => void): void => {
     cy.then(() => {
-        //@ts-ignore
+        // @ts-ignore
         Cypress.log({groupStart: true, displayName: '[ STEP ]', message: `${message}`});
     }).then(() => {
         func();
     }).then(() => {
-        //@ts-ignore
+        // @ts-ignore
         Cypress.log({groupEnd: true, emitOnly: true});
     });
 };


### PR DESCRIPTION
```ts
  /**
   * Creates a foldable test-case step with corresponding message in Cypress log
   * @param {string} message - folder's message
   * @param {() => void} func - function to be executed and wrapped into the folder
   * @returns void
   * @example
   *         cy.step('Navigate to the destination point', () => {
   *              cy.get('selector').click();
   *              ...
   *         });
   *
   *        cy.step('Do something', () => {
   *              cy.get('element').click();
   *              ...
   *         });
   */
```

<img width="664" alt="image" src="https://github.com/user-attachments/assets/b7fa6b7b-2cf9-4db8-82a6-c1096671225b" />
