### PR TITLE
chore: disable browser console errors lookup by default

### DIFF
--- a/src/support/registerSupport.ts
+++ b/src/support/registerSupport.ts
@@ -31,4 +31,5 @@ export const registerSupport = (): void => {
     // for all tests without needing to call it explicitly in each test file.
     // This is useful for capturing and logging JavaScript errors across all tests.
     JahiaHooks.attach();
+    JahiaHooks.disable();
 };


### PR DESCRIPTION
Disable JS Console errors logger by default.