### PR TITLE
feat: backport export made in 6.x.x

### DIFF
--- a/src/support/provisioning/index.ts
+++ b/src/support/provisioning/index.ts
@@ -2,3 +2,4 @@ export * from './executeGroovy';
 export * from './runProvisioningScript';
 export * from './installModule';
 export * from './uninstallModule';
+export * from './installConfig';


### PR DESCRIPTION
### Description

Backport missing export after releasing version 6.3.1 from a 6.x.x branch to keep upcoming breaking 7.0.0 in main