### PR TITLE
fix: force removal of the previous version of a module

### DIFF
--- a/env.provision.sh
+++ b/env.provision.sh
@@ -76,7 +76,7 @@ if [[ -d artifacts/ ]]; then
   for file in $(ls -1 *-SNAPSHOT.jar | sort -n)
   do
     echo "$(date +'%d %B %Y - %k:%M') [MODULE_INSTALL] == Submitting module from: $file =="
-    curl -u root:${SUPER_USER_PASSWORD} -X POST ${JAHIA_URL}/modules/api/provisioning --form script='[{"installAndStartBundle":"'"$file"'", "forceUpdate":true}]' --form file=@$file
+    curl -u root:${SUPER_USER_PASSWORD} -X POST ${JAHIA_URL}/modules/api/provisioning --form script='[{"installOrUpgradeBundle":"'"$file"'", "forceUpdate":true}]' --form file=@$file
     echo
     echo "$(date +'%d %B %Y - %k:%M') [MODULE_INSTALL] == Module submitted =="
   done
@@ -85,7 +85,7 @@ if [[ -d artifacts/ ]]; then
   for file in $(ls -1 *-SNAPSHOT.tgz | sort -n)
     do
       echo "$(date +'%d %B %Y - %k:%M') [MODULE_INSTALL] == Submitting Javascript module from: $file =="
-      curl -u root:${SUPER_USER_PASSWORD} -X POST ${JAHIA_URL}/modules/api/provisioning --form script='[{"installAndStartBundle":"'"$file"'", "forceUpdate":true}]' --form file=@$file
+      curl -u root:${SUPER_USER_PASSWORD} -X POST ${JAHIA_URL}/modules/api/provisioning --form script='[{"installOrUpgradeBundle":"'"$file"'", "forceUpdate":true}]' --form file=@$file
       echo
       echo "$(date +'%d %B %Y - %k:%M') [MODULE_INSTALL] == Javascript Module submitted =="
     done


### PR DESCRIPTION
This should fix an issue noticed on graphql-dxm-provider, that resulted in an invalid GraphQL schema.

I found out that the issue was caused by having two versions of graphql-dxm-provider installed on the platform:
 - An older version, coming with from Jahia and stopped
 - A newer version, installed via provisioning

<img width="929" height="69" alt="Screenshot 2025-12-17 at 14 00 47" src="https://github.com/user-attachments/assets/3eb490ac-51f7-4130-bff8-a7a67b4c947f" />

This is quite a rare occurence, only happening when the pack was not updated just after a release.

According to the readme: https://github.com/Jahia/jahia-private/blob/0e47150ebf19a06c6e8326d3d5ccb50eec8970a7/bundles/provisioning/README.md?plain=1#L137 using the "installOrUpgradeBundle" command should prevent this from happening.

Note that I did not use the new commands as this must remain compatible with older versions of Jahia.
