### PR TITLE
feat: Support an optional Jahia processing URL

### DIFF
--- a/src/plugins/env.ts
+++ b/src/plugins/env.ts
@@ -3,15 +3,18 @@ const env = (on:Cypress.PluginEvents, config: Cypress.PluginConfigOptions):Cypre
         console.warn('No environment set, will use default values');
         config.baseUrl = 'http://localhost:8080';
         config.env.JAHIA_URL = 'http://localhost:8080';
+        config.env.JAHIA_PROCESSING_URL = 'http://localhost:8080';
         config.env.SUPER_USER_PASSWORD = 'root1234';
     } else {
         console.log('Setting environment');
         config.baseUrl = process.env.JAHIA_URL;
         config.env.JAHIA_URL = process.env.JAHIA_URL;
+        config.env.JAHIA_PROCESSING_URL = process.env.JAHIA_PROCESSING_URL;
         config.env.SUPER_USER_PASSWORD = process.env.SUPER_USER_PASSWORD;
     }
 
     console.log('JAHIA_URL =', config.env.JAHIA_URL);
+    console.log('JAHIA_PROCESSING_URL =', config.env.JAHIA_PROCESSING_URL);
     console.log('SUPER_USER_PASSWORD =', config.env.SUPER_USER_PASSWORD);
 
     return config;


### PR DESCRIPTION
Closes https://github.com/Jahia/jahia-private/issues/4598.
### Description
Add support for an optional `JAHIA_PROCESSING_URL` environment variable that can be used to specify the Jahia URL to use to run the provisioning files against.
Typically, this can be used in cluster where the provisioning should be run against the processing server, but the Cypress tests should use the HAProxy (with the browsing nodes in its pool).

If not set, it defaults to the value of `JAHIA_URL` (i.e. the same Jahia URL is used for both provisioning and as base URL for Cypress).

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
