### PR TITLE
feat: prevent stacktrace when removing a user that does not exists

### DIFF
--- a/fixtures/groovy/admin/deleteUser.groovy
+++ b/fixtures/groovy/admin/deleteUser.groovy
@@ -10,11 +10,12 @@ JCRTemplate.getInstance().doExecuteWithSystemSession(new JCRCallback() {
         log.info("Delete user : USER_NAME" );
 
         JahiaUserManagerService userManagerService = JahiaUserManagerService.getInstance();
-        try {
-            userManagerService.deleteUser(userManagerService.getUserPath("USER_NAME"), session);
+        def user = userManagerService.getUserPath("USER_NAME");
+        if (user) {
+            userManagerService.deleteUser(user, session);
             session.save();
-        } catch (Throwable e) {
-            log.warn("Cannot delete user USER_NAME because {}", e.getMessage())
+        } else {
+            log.warn("User USER_NAME cannot be deleted. User not found");
         }
         return null;
     }


### PR DESCRIPTION
### Description
When a user is removed using utility method `deleteUser`  but not existing a stacktrace is produced 
```
2026-01-08 08:00:37,050: INFO  [Patcher] - Found patch scripts file [/usr/local/tomcat/temp/tmp-7207005998524095040.groovy]. Executing...
2026-01-08 08:00:37,050: INFO  [GroovyPatcher] - Delete user : myUser
2026-01-08 08:00:37,051: ERROR [GroovyPatcher] - Execution of script failed with error: javax.script.ScriptException: java.lang.NullPointerException: Cannot invoke "String.contains(java.lang.CharSequence)" because "path" is null
javax.script.ScriptException: javax.script.ScriptException: java.lang.NullPointerException: Cannot invoke "String.contains(java.lang.CharSequence)" because "path" is null
	at org.codehaus.groovy.jsr223.GroovyScriptEngineImpl.eval(GroovyScriptEngineImpl.java:158) ~[groovy-jsr223-3.0.8.jar:3.0.8]
	at org.jahia.tools.patches.GroovyPatcher.executeScript(GroovyPatcher.java:88) ~[jahia-impl-8.2.3.0-SNAPSHOT.jar:?]
	at org.jahia.tools.patches.Patcher.executeScript(Patcher.java:224) ~[jahia-impl-8.2.3.0-SNAPSHOT.jar:?]
	at org.jahia.tools.patches.Patcher.executeScripts(Patcher.java:206) ~[jahia-impl-8.2.3.0-SNAPSHOT.jar:?]
	at org.jahia.bundles.provisioning.impl.operations.ExecuteScript.perform(ExecuteScript.java:77) ~[?:?]
	at org.jahia.bundles.provisioning.impl.ProvisioningManagerImpl.lambda$executeScript$3(ProvisioningManagerImpl.java:161) ~[?:?]
	at java.base/java.util.Optional.ifPresent(Optional.java:178) ~[?:?]
	at org.jahia.bundles.provisioning.impl.ProvisioningManagerImpl.lambda$executeScript$4(ProvisioningManagerImpl.java:158) ~[?:?]
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511) ~[?:?]
	at org.jahia.bundles.provisioning.impl.ProvisioningManagerImpl.executeScript(ProvisioningManagerImpl.java:152) ~[?:?]
	at org.jahia.bundles.provisioning.impl.ProvisioningManagerImpl.executeScript(ProvisioningManagerImpl.java:145) ~[?:?]
	at org.jahia.bundles.provisioning.rest.ProvisioningResource.executeMultipart(ProvisioningResource.java:124) ~[?:?]
	... suppressed 3 lines
	at java.base/java.lang.reflect.Method.invoke(Method.java:569) ~[?:?]
	... suppressed 41 lines
	at org.jahia.bin.filters.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:143) [jahia-impl-8.2.3.0-SNAPSHOT.jar:?]
	at org.jahia.modules.jahiacsrfguard.filters.CsrfGuardJavascriptFilter.doFilter(CsrfGuardJavascriptFilter.java:91) [!/:4.2.0]
	at org.jahia.bin.filters.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:145) [jahia-impl-8.2.3.0-SNAPSHOT.jar:?]
	... suppressed 3 lines
	at org.jahia.services.seo.urlrewrite.UrlRewriteFilter.doFilter(UrlRewriteFilter.java:124) [jahia-impl-8.2.3.0-SNAPSHOT.jar:?]
	at org.jahia.bin.filters.ServletFilter.doFilter(ServletFilter.java:74) [jahia-impl-8.2.3.0-SNAPSHOT.jar:?]
	at org.jahia.bin.filters.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:145) [jahia-impl-8.2.3.0-SNAPSHOT.jar:?]
	at org.jahia.modules.tools.csrf.ToolsAccessTokenFilter.doFilter(ToolsAccessTokenFilter.java:74) [!/:5.2.2]
	at org.jahia.bin.filters.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:145) [jahia-impl-8.2.3.0-SNAPSHOT.jar:?]
	at org.jahia.modules.jahiacsrfguard.filters.CsrfGuardServletFilterWrapper.doFilter(CsrfGuardServletFilterWrapper.java:80) [!/:4.2.0]
	at org.jahia.bin.filters.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:145) [jahia-impl-8.2.3.0-SNAPSHOT.jar:?]
	at org.jahia.bundles.securityfilter.jwt.JWTFilter.doFilter(JWTFilter.java:137) [!/:?]
	at org.jahia.bin.filters.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:145) [jahia-impl-8.2.3.0-SNAPSHOT.jar:?]
	at org.jahia.bundles.securityfilter.core.ContextFilter.doFilter(ContextFilter.java:91) [!/:?]
	at org.jahia.bin.filters.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:145) [jahia-impl-8.2.3.0-SNAPSHOT.jar:?]
	at org.jahia.bin.filters.jcr.JcrSessionFilter.doFilter(JcrSessionFilter.java:152) [jahia-impl-8.2.3.0-SNAPSHOT.jar:?]
	at org.jahia.bin.filters.ServletFilter.doFilter(ServletFilter.java:74) [jahia-impl-8.2.3.0-SNAPSHOT.jar:?]
	at org.jahia.bin.filters.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:145) [jahia-impl-8.2.3.0-SNAPSHOT.jar:?]
	at org.jahia.bundles.cache.client.filter.ClientCacheFilter.doFilter(ClientCacheFilter.java:90) [!/:?]
	at org.jahia.bin.filters.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:145) [jahia-impl-8.2.3.0-SNAPSHOT.jar:?]
	... suppressed 12 lines
	at org.jahia.bin.filters.ServletFilter.doFilter(ServletFilter.java:74) [jahia-impl-8.2.3.0-SNAPSHOT.jar:?]
	at org.jahia.bin.filters.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:145) [jahia-impl-8.2.3.0-SNAPSHOT.jar:?]
	at org.jahia.bundles.filters.maintenance.MaintenanceFilter.doFilter(MaintenanceFilter.java:123) [!/:?]
	at org.jahia.bin.filters.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:145) [jahia-impl-8.2.3.0-SNAPSHOT.jar:?]
	at org.jahia.bin.filters.HttpHeadRequestFilter.doFilter(HttpHeadRequestFilter.java:85) [jahia-impl-8.2.3.0-SNAPSHOT.jar:?]
	at org.jahia.bin.filters.ServletFilter.doFilter(ServletFilter.java:74) [jahia-impl-8.2.3.0-SNAPSHOT.jar:?]
	at org.jahia.bin.filters.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:145) [jahia-impl-8.2.3.0-SNAPSHOT.jar:?]
	... suppressed 2 lines
	at org.jahia.bin.filters.ServletFilter.doFilter(ServletFilter.java:74) [jahia-impl-8.2.3.0-SNAPSHOT.jar:?]
	at org.jahia.bin.filters.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:145) [jahia-impl-8.2.3.0-SNAPSHOT.jar:?]
	at org.jahia.bin.filters.ChainedErrorHandlerFilter.doFilter(ChainedErrorHandlerFilter.java:33) [jahia-impl-8.2.3.0-SNAPSHOT.jar:?]
	at org.jahia.bin.filters.ServletFilter.doFilter(ServletFilter.java:74) [jahia-impl-8.2.3.0-SNAPSHOT.jar:?]
	at org.jahia.bin.filters.CompositeFilter$VirtualFilterChain.doFilter(CompositeFilter.java:145) [jahia-impl-8.2.3.0-SNAPSHOT.jar:?]
	at org.jahia.bin.filters.CompositeFilter.doFilter(CompositeFilter.java:124) [jahia-impl-8.2.3.0-SNAPSHOT.jar:?]
	... suppressed 13 lines
	at org.apache.coyote.http11.Http11Processor.service(Http11Processor.java:398) [tomcat-coyote.jar:9.0.113]
	at org.apache.coyote.AbstractProcessorLight.process(AbstractProcessorLight.java:63) [tomcat-coyote.jar:9.0.113]
	at org.apache.coyote.AbstractProtocol$ConnectionHandler.process(AbstractProtocol.java:939) [tomcat-coyote.jar:9.0.113]
	... suppressed 5 lines
	at java.base/java.lang.Thread.run(Thread.java:840) [?:?]
Caused by: javax.script.ScriptException: java.lang.NullPointerException: Cannot invoke "String.contains(java.lang.CharSequence)" because "path" is null
	at org.codehaus.groovy.jsr223.GroovyScriptEngineImpl.eval(GroovyScriptEngineImpl.java:320) ~[groovy-jsr223-3.0.8.jar:3.0.8]
	at org.codehaus.groovy.jsr223.GroovyScriptEngineImpl.eval(GroovyScriptEngineImpl.java:155) ~[groovy-jsr223-3.0.8.jar:3.0.8]
	... 127 more
Caused by: java.lang.NullPointerException: Cannot invoke "String.contains(java.lang.CharSequence)" because "path" is null
	at org.jahia.services.content.JCRSessionWrapper.getItem(JCRSessionWrapper.java:340) ~[jahia-impl-8.2.3.0-SNAPSHOT.jar:?]
	at org.jahia.services.content.JCRSessionWrapper.getNode(JCRSessionWrapper.java:420) ~[jahia-impl-8.2.3.0-SNAPSHOT.jar:?]
	at org.jahia.services.content.JCRSessionWrapper.getNode(JCRSessionWrapper.java:416) ~[jahia-impl-8.2.3.0-SNAPSHOT.jar:?]
	at org.jahia.services.usermanager.JahiaUserManagerService.deleteUser(JahiaUserManagerService.java:810) ~[jahia-impl-8.2.3.0-SNAPSHOT.jar:?]
	at org.jahia.api.usermanager.JahiaUserManagerService$deleteUser$1.call(Unknown Source) ~[?:?]
	at Script18$1.doInJCR(Script18.groovy:13) ~[?:?]
	at org.jahia.services.content.JCRTemplate.doExecuteWithSystemSessionAsUser(JCRTemplate.java:159) ~[jahia-impl-8.2.3.0-SNAPSHOT.jar:?]
	at org.jahia.services.content.JCRTemplate.doExecuteWithSystemSession(JCRTemplate.java:111) ~[jahia-impl-8.2.3.0-SNAPSHOT.jar:?]
	at org.jahia.api.content.JCRTemplate$doExecuteWithSystemSession.call(Unknown Source) ~[?:?]
	at Script18.run(Script18.groovy:7) ~[?:?]
	at org.codehaus.groovy.jsr223.GroovyScriptEngineImpl.eval(GroovyScriptEngineImpl.java:317) ~[groovy-jsr223-3.0.8.jar:3.0.8]
	at org.codehaus.groovy.jsr223.GroovyScriptEngineImpl.eval(GroovyScriptEngineImpl.java:155) ~[groovy-jsr223-3.0.8.jar:3.0.8]
	... 127 more
```

This change to remove it and only display a warn message instead
```
2026-01-08 08:02:47,160: WARN  [GroovyPatcher] - Cannot delete user myUser because Cannot invoke "String.contains(java.lang.CharSequence)" because "path" is null
```


### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
