### PR TITLE
feat: allow to start the test environment without cypress image

### DIFF
--- a/ci.startup.sh
+++ b/ci.startup.sh
@@ -32,7 +32,7 @@ if [[ "${JAHIA_CLUSTER_ENABLED}" == "true" ||  ${JAHIA_CLUSTER_ENABLED} == true 
 fi
 
 echo "$(date +'%d %B %Y - %k:%M') == Starting environment =="
-docker-compose ${CLUSTER_PROFILE} up -d --renew-anon-volumes
+docker-compose ${CLUSTER_PROFILE} up -d --renew-anon-volumes $(docker-compose config --services | grep -v "cypress")
 if [[ "$1" != "notests" ]]; then
     docker ps -a
     docker stats --no-stream


### PR DESCRIPTION
### Description
Currently when running `ci.startup.sh` but the cypress image not build, none of the containers can be started because of this missing image. 
This make the [`notests`](https://github.com/Jahia/jahia-cypress/blob/97fe6b6de08cccfaaf38efe20e2603e62480e0e8/ci.startup.sh#L36) usable, as now the cypress image is not mandatory

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
