### PR TITLE
feat: add lock/unlock node function

### DIFF
--- a/fixtures/graphql/jcr/mutation/lockNode.graphql
+++ b/fixtures/graphql/jcr/mutation/lockNode.graphql
@@ -1,0 +1,7 @@
+mutation lockNode($pathOrId: String!){
+  jcr{
+    mutateNode(pathOrId: $pathOrId){
+      lock
+    }
+  }
+}

--- a/fixtures/graphql/jcr/mutation/unlockNode.graphql
+++ b/fixtures/graphql/jcr/mutation/unlockNode.graphql
@@ -1,0 +1,7 @@
+mutation unlockNode($pathOrId: String!){
+  jcr{
+    mutateNode(pathOrId: $pathOrId){
+      unlock
+    }
+  }
+}

--- a/src/utils/JCRHelper.ts
+++ b/src/utils/JCRHelper.ts
@@ -131,3 +131,21 @@ export const uploadFile = (fixturePath: string, parentPathOrId: string, name: st
             });
         });
 };
+
+export const lockNode = (pathOrId: string): Cypress.Chainable => {
+    return cy.apollo({
+        mutationFile: 'graphql/jcr/mutation/lockNode.graphql',
+        variables: {
+            pathOrId: pathOrId
+        }
+    });
+};
+
+export const unlockNode = (pathOrId: string): Cypress.Chainable => {
+    return cy.apollo({
+        mutationFile: 'graphql/jcr/mutation/unlockNode.graphql',
+        variables: {
+            pathOrId: pathOrId
+        }
+    });
+};


### PR DESCRIPTION
### Description
This pull request adds support for locking and unlocking nodes via GraphQL mutations and exposes helper functions for use in Cypress tests. The main changes are grouped into GraphQL fixture additions and utility function enhancements.

**GraphQL fixture additions:**

* Added `lockNode` mutation fixture to `fixtures/graphql/jcr/mutation/lockNode.graphql` for locking nodes by `pathOrId`.
* Added `unlockNode` mutation fixture to `fixtures/graphql/jcr/mutation/unlockNode.graphql` for unlocking nodes by `pathOrId`.

**Utility function enhancements:**

* Added `lockNode` and `unlockNode` helper functions to `src/utils/JCRHelper.ts` to invoke the new GraphQL mutations from Cypress tests.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
