### PR TITLE
feat: improve cypress logs of script execution

### DIFF
--- a/.chachalog/_MaYeh4f.md
+++ b/.chachalog/_MaYeh4f.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/cypress": minor
+---
+
+Improve cypress logs of script execution, now groovy / provisioning and graphql calls provides more information (#214)

--- a/src/support/apollo/apollo.ts
+++ b/src/support/apollo/apollo.ts
@@ -17,8 +17,8 @@ declare global {
     }
 }
 
-export type FileQueryOptions = Partial<QueryOptions> & { queryFile?: string }
-export type FileMutationOptions = Partial<MutationOptions> & { mutationFile?: string }
+export type FileQueryOptions = Partial<QueryOptions> & { queryFile?: string; sourcePackage?: string }
+export type FileMutationOptions = Partial<MutationOptions> & { mutationFile?: string; sourcePackage?: string }
 export type ApolloOptions = (QueryOptions | MutationOptions | FileQueryOptions | FileMutationOptions) & Partial<Cypress.Loggable>;
 
 function isQuery(options: ApolloOptions): options is QueryOptions {
@@ -68,14 +68,16 @@ export const apollo = function (apollo: ApolloClient<any> = this.currentApolloCl
     if (!apollo) {
         cy.apolloClient().apollo(optionsWithDefaultCache);
     } else if (isQueryFile(optionsWithDefaultCache)) {
-        const {queryFile, ...apolloOptions} = optionsWithDefaultCache;
+        const {queryFile, sourcePackage, ...apolloOptions} = optionsWithDefaultCache as FileQueryOptions & Partial<Cypress.Loggable>;
         cy.fixture(queryFile).then(content => {
-            cy.apollo({query: gql(content), ...apolloOptions, _sourceFile: queryFile} as ApolloOptions);
+            const fileLabel = sourcePackage ? `${queryFile} @ ${sourcePackage}` : queryFile;
+            cy.apollo({query: gql(content), ...apolloOptions, _sourceFile: fileLabel} as ApolloOptions);
         });
     } else if (isMutationFile(optionsWithDefaultCache)) {
-        const {mutationFile, ...apolloOptions} = optionsWithDefaultCache;
+        const {mutationFile, sourcePackage, ...apolloOptions} = optionsWithDefaultCache as FileMutationOptions & Partial<Cypress.Loggable>;
         cy.fixture(mutationFile).then(content => {
-            cy.apollo({mutation: gql(content), ...apolloOptions, _sourceFile: mutationFile} as ApolloOptions);
+            const fileLabel = sourcePackage ? `${mutationFile} @ ${sourcePackage}` : mutationFile;
+            cy.apollo({mutation: gql(content), ...apolloOptions, _sourceFile: fileLabel} as ApolloOptions);
         });
     } else {
         const {log = true, ...apolloOptions} = optionsWithDefaultCache;

--- a/src/support/apollo/apollo.ts
+++ b/src/support/apollo/apollo.ts
@@ -70,12 +70,12 @@ export const apollo = function (apollo: ApolloClient<any> = this.currentApolloCl
     } else if (isQueryFile(optionsWithDefaultCache)) {
         const {queryFile, ...apolloOptions} = optionsWithDefaultCache;
         cy.fixture(queryFile).then(content => {
-            cy.apollo({query: gql(content), ...apolloOptions});
+            cy.apollo({query: gql(content), ...apolloOptions, _sourceFile: queryFile} as ApolloOptions);
         });
     } else if (isMutationFile(optionsWithDefaultCache)) {
         const {mutationFile, ...apolloOptions} = optionsWithDefaultCache;
         cy.fixture(mutationFile).then(content => {
-            cy.apollo({mutation: gql(content), ...apolloOptions});
+            cy.apollo({mutation: gql(content), ...apolloOptions, _sourceFile: mutationFile} as ApolloOptions);
         });
     } else {
         const {log = true, ...apolloOptions} = optionsWithDefaultCache;

--- a/src/support/apollo/apollo.ts
+++ b/src/support/apollo/apollo.ts
@@ -4,7 +4,9 @@
 /// <reference types="cypress" />
 
 import {ApolloClient, ApolloQueryResult, FetchResult, MutationOptions, QueryOptions} from '@apollo/client/core';
+import {DocumentNode} from '@apollo/client/core';
 import gql from 'graphql-tag';
+import {FieldNode, getOperationAST, print} from 'graphql';
 
 declare global {
     namespace Cypress {
@@ -31,10 +33,36 @@ function isMutationFile(options: ApolloOptions): options is FileMutationOptions 
     return (<FileMutationOptions>options).mutationFile !== undefined;
 }
 
+function getOperationLabel(doc: DocumentNode, opType: 'Query' | 'Mutation'): string {
+    const opDef = getOperationAST(doc);
+    if (opDef?.name?.value) {
+        return `[${opType}] ${opDef.name.value}`;
+    }
+
+    // Anonymous operation: traverse up to 2 selection levels for a meaningful label
+    const firstSel = opDef?.selectionSet?.selections?.[0];
+    if (firstSel?.kind === 'Field') {
+        const firstName = (firstSel as FieldNode).name.value;
+        const secondSel = (firstSel as FieldNode).selectionSet?.selections?.[0];
+        if (secondSel?.kind === 'Field') {
+            return `[${opType}] ${firstName} › ${(secondSel as FieldNode).name.value}`;
+        }
+
+        return `[${opType}] ${firstName}`;
+    }
+
+    return `[${opType}]`;
+}
+
+function getQueryBody(doc: DocumentNode): string {
+    return doc?.loc?.source?.body ?? print(doc);
+}
+
 // eslint-disable-next-line default-param-last, @typescript-eslint/no-shadow
 export const apollo = function (apollo: ApolloClient<any> = this.currentApolloClient, options: ApolloOptions): void {
     let result : ApolloQueryResult<any> | FetchResult;
     let logger : Cypress.Log;
+    let duration: number;
     const optionsWithDefaultCache: ApolloOptions = {fetchPolicy: 'no-cache', ...options};
 
     if (!apollo) {
@@ -51,31 +79,53 @@ export const apollo = function (apollo: ApolloClient<any> = this.currentApolloCl
         });
     } else {
         const {log = true, ...apolloOptions} = optionsWithDefaultCache;
+
+        const doc = isQuery(apolloOptions) ?
+            (apolloOptions as QueryOptions).query :
+            (apolloOptions as MutationOptions).mutation;
+        const opType = isQuery(apolloOptions) ? 'Query' : 'Mutation';
+        const operationLabel = getOperationLabel(doc, opType);
+        const queryBody = getQueryBody(doc);
+        const variables = (apolloOptions as any).variables;
+
         if (log) {
             logger = Cypress.log({
                 autoEnd: false,
                 name: 'apollo',
                 displayName: 'apollo',
-                message: isQuery(apolloOptions) ? `Execute Graphql Query: ${apolloOptions.query.loc.source.body}` : `Execute Graphql Mutation: ${apolloOptions.mutation.loc.source.body}`,
+                message: operationLabel,
                 consoleProps: () => {
+                    const errors = (result as any)?.errors ?? (result as any)?.graphQLErrors ?? null;
+                    const isCaughtError = result instanceof Error;
+                    const hasErrors = (errors?.length > 0) || isCaughtError;
                     return {
-                        Options: apolloOptions,
+                        Operation: operationLabel,
+                        Variables: variables ?? {},
+                        [`${opType} Body`]: queryBody,
+                        Duration: duration === undefined ? 'pending' : `${duration}ms`,
+                        Status: hasErrors ?
+                            `error${isCaughtError ? `: ${(result as unknown as Error).message}` : ''}` :
+                            'success',
+                        Data: (result as any)?.data ?? null,
+                        Errors: errors,
                         Yielded: result
                     };
                 }
             });
         }
 
-        cy.wrap({}, {log: true})
+        const startTime = Date.now();
+        cy.wrap({}, {log: false})
             .then(() => (isQuery(optionsWithDefaultCache) ? apollo.query(optionsWithDefaultCache).catch(error => {
-                cy.log(`Caught Graphql Query Error: ${JSON.stringify(error)}`);
+                cy.log(`Caught GraphQL query error: ${(error as any)?.message ?? JSON.stringify(error)}`);
                 return error;
             }) : apollo.mutate(optionsWithDefaultCache).catch(error => {
-                cy.log(`Caught Graphql Mutation Error: ${JSON.stringify(error)}`);
+                cy.log(`Caught GraphQL mutation error: ${(error as any)?.message ?? JSON.stringify(error)}`);
                 return error;
             }))
                 .then(r => {
                     result = r;
+                    duration = Date.now() - startTime;
                     logger?.end();
                     return r;
                 })

--- a/src/support/apollo/apollo.ts
+++ b/src/support/apollo/apollo.ts
@@ -87,13 +87,17 @@ export const apollo = function (apollo: ApolloClient<any> = this.currentApolloCl
         const operationLabel = getOperationLabel(doc, opType);
         const queryBody = getQueryBody(doc);
         const variables = (apolloOptions as any).variables;
+        const sourceLabel = (optionsWithDefaultCache as any)._sourceFile ? ` (${(optionsWithDefaultCache as any)._sourceFile})` : '';
+        const variablesLabel = variables && Object.keys(variables).length > 0 ?
+            ` — ${JSON.stringify(variables)}` :
+            '';
 
         if (log) {
             logger = Cypress.log({
                 autoEnd: false,
                 name: 'apollo',
                 displayName: 'apollo',
-                message: operationLabel,
+                message: `${operationLabel}${sourceLabel}${variablesLabel}`,
                 consoleProps: () => {
                     const errors = (result as any)?.errors ?? (result as any)?.graphQLErrors ?? null;
                     const isCaughtError = result instanceof Error;
@@ -126,6 +130,13 @@ export const apollo = function (apollo: ApolloClient<any> = this.currentApolloCl
                 .then(r => {
                     result = r;
                     duration = Date.now() - startTime;
+                    if (logger) {
+                        const errors = (r as any)?.errors ?? (r as any)?.graphQLErrors;
+                        const hasErrors = (r instanceof Error) || (errors?.length > 0);
+                        const prefix = hasErrors ? '❌ ' : '✅ ';
+                        logger.set('message', `${prefix}${operationLabel}${sourceLabel}${variablesLabel}`);
+                    }
+
                     logger?.end();
                     return r;
                 })

--- a/src/support/provisioning/executeGroovy.md
+++ b/src/support/provisioning/executeGroovy.md
@@ -51,4 +51,10 @@ cy.executeGroovy("script.groovy").then(result => { console.log(result) })
 
 ## Command Log
 
-No log
+When clicking on `groovy` within the command log, the console outputs the following:
+
+- **Script**: The name of the Groovy script file executed.
+- **Replacements**: The replacement map applied to the script, if any.
+- **Server**: The Jahia server URL targeted.
+- **Duration**: Elapsed time from invocation to completion.
+- **Result**: The first operation result returned by the provisioning API.

--- a/src/support/provisioning/executeGroovy.ts
+++ b/src/support/provisioning/executeGroovy.ts
@@ -25,6 +25,24 @@ const serverDefaults = {
 };
 
 export const executeGroovy = function (scriptFile: string, replacements?: { [key: string]: string }, jahiaServer: JahiaServer = serverDefaults): void {
+    let result: any;
+    let duration: number;
+    const startTime = Date.now();
+
+    const logger = Cypress.log({
+        autoEnd: false,
+        name: 'executeGroovy',
+        displayName: 'groovy',
+        message: scriptFile,
+        consoleProps: () => ({
+            Script: scriptFile,
+            Replacements: replacements ?? {},
+            Server: jahiaServer.url,
+            Duration: duration === undefined ? 'pending' : `${duration}ms`,
+            Result: result
+        })
+    });
+
     cy.runProvisioningScript({
         script: {
             fileContent: '- executeScript: "' + scriptFile + '"',
@@ -36,6 +54,12 @@ export const executeGroovy = function (scriptFile: string, replacements?: { [key
             type: 'text/plain',
             encoding: 'utf-8'
         }],
-        jahiaServer
-    }).then(r => r[0]);
+        jahiaServer,
+        options: {log: false}
+    }).then(r => {
+        result = (r as any)?.[0];
+        duration = Date.now() - startTime;
+        logger?.end();
+        return result;
+    });
 };

--- a/src/support/provisioning/executeGroovy.ts
+++ b/src/support/provisioning/executeGroovy.ts
@@ -27,20 +27,37 @@ const serverDefaults = {
 export const executeGroovy = function (scriptFile: string, replacements?: { [key: string]: string }, jahiaServer: JahiaServer = serverDefaults): void {
     let result: any;
     let duration: number;
+    let scriptContent: string;
     const startTime = Date.now();
+
+    const replacementsLabel = replacements && Object.keys(replacements).length > 0 ?
+        ` — ${JSON.stringify(replacements)}` :
+        '';
 
     const logger = Cypress.log({
         autoEnd: false,
         name: 'executeGroovy',
         displayName: 'groovy',
-        message: scriptFile,
+        message: `${scriptFile}${replacementsLabel}`,
         consoleProps: () => ({
             Script: scriptFile,
+            'Script Content': scriptContent ?? '(loading...)',
             Replacements: replacements ?? {},
             Server: jahiaServer.url,
             Duration: duration === undefined ? 'pending' : `${duration}ms`,
             Result: result
         })
+    });
+
+    cy.fixture(scriptFile, 'utf-8').then((content: string) => {
+        let processed = content;
+        if (replacements) {
+            Object.keys(replacements).forEach(k => {
+                processed = processed.replaceAll(k, replacements[k]);
+            });
+        }
+
+        scriptContent = processed;
     });
 
     cy.runProvisioningScript({
@@ -59,6 +76,9 @@ export const executeGroovy = function (scriptFile: string, replacements?: { [key
     }).then(r => {
         result = (r as any)?.[0];
         duration = Date.now() - startTime;
+        const hasFailed = typeof result === 'string' && result.includes('.failed');
+        const prefix = hasFailed ? '❌ ' : '✅ ';
+        logger.set('message', `${prefix}${scriptFile}${replacementsLabel}`);
         logger?.end();
         return result;
     });

--- a/src/support/provisioning/runProvisioningScript.ts
+++ b/src/support/provisioning/runProvisioningScript.ts
@@ -82,7 +82,7 @@ const serverDefaults: JahiaServer = {
 };
 
 function isFormFile(script: FormFile | StringDictionary[]): script is FormFile {
-    return Boolean((script as FormFile).fileContent || (script as FormFile).fileName);
+    return Boolean((script as FormFile)?.fileContent || (script as FormFile)?.fileName);
 }
 
 function getScriptSummary(script: FormFile | StringDictionary[]): string {
@@ -92,10 +92,10 @@ function getScriptSummary(script: FormFile | StringDictionary[]): string {
         }
 
         if (script.fileContent) {
-            // Parse first operation name from YAML list: "- operationName: ..."
-            const yamlMatch = script.fileContent.match(/^\s*-\s+(\w+)\s*:/m);
+            // Parse first operation and its value from YAML list: "- operationName: value"
+            const yamlMatch = script.fileContent.match(/^\s*-\s+(\w+)\s*:\s*"?([^"\n]+)"?/m);
             if (yamlMatch) {
-                return yamlMatch[1];
+                return `${yamlMatch[1]}: ${yamlMatch[2].trim()}`;
             }
 
             // Parse first operation name from JSON array: [{"operationName": ...}]
@@ -113,7 +113,7 @@ function getScriptSummary(script: FormFile | StringDictionary[]): string {
         return 'inline script';
     }
 
-    if (script.length === 0) {
+    if (!script || script.length === 0) {
         return 'empty script';
     }
 
@@ -121,13 +121,35 @@ function getScriptSummary(script: FormFile | StringDictionary[]): string {
     return ops.length === 1 ? ops[0] : `[${ops.join(', ')}]`;
 }
 
-export const runProvisioningScript = ({
-    script,
-    files,
-    jahiaServer = serverDefaults,
-    options = {log: true},
-    requestOptions = {}
-}: RunProvisioningScriptParams): void => {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const runProvisioningScript = (paramsOrScript: RunProvisioningScriptParams | FormFile | StringDictionary[], ...rest: any[]): void => {
+    // Backward-compatible: support old positional signature
+    // runProvisioningScript(script, files, jahiaServer, options, timeout)
+    let script: FormFile | StringDictionary[];
+    let files: FormFile[];
+    let jahiaServer: JahiaServer;
+    let options: Cypress.Loggable;
+    let requestOptions: Partial<Cypress.RequestOptions>;
+
+    const isLegacyCall = Array.isArray(paramsOrScript) ||
+        (paramsOrScript as FormFile).fileContent !== undefined ||
+        (paramsOrScript as FormFile).fileName !== undefined;
+
+    if (isLegacyCall) {
+        script = paramsOrScript as FormFile | StringDictionary[];
+        files = rest[0];
+        jahiaServer = rest[1] ?? serverDefaults;
+        options = rest[2] ?? {log: true};
+        requestOptions = {};
+    } else {
+        const params = paramsOrScript as RunProvisioningScriptParams;
+        script = params.script;
+        files = params.files;
+        jahiaServer = params.jahiaServer ?? serverDefaults;
+        options = params.options ?? {log: true};
+        requestOptions = params.requestOptions ?? {};
+    }
+
     const formData = new FormData();
 
     if (isFormFile(script)) {
@@ -151,19 +173,25 @@ export const runProvisioningScript = ({
     let result: any;
     let logger: Cypress.Log;
 
+    const scriptSummary = getScriptSummary(script);
+    const replacementsFromFiles = files
+        ?.filter(f => f.replacements && Object.keys(f.replacements).length > 0)
+        .map(f => `${f.fileName}: ${JSON.stringify(f.replacements)}`);
+
     if (options.log) {
         logger = Cypress.log({
             autoEnd: false,
             name: 'runProvisioningScript',
             displayName: 'provScript',
-            message: `${getScriptSummary(script)} @ ${jahiaServer.url}`,
+            message: `${scriptSummary} @ ${jahiaServer.url}`,
             consoleProps: () => {
                 return {
                     Script: script,
                     Operations: isFormFile(script) ?
                         undefined :
-                        script.map(op => `${Object.keys(op)[0]}: ${Object.values(op)[0]}`),
+                        script?.map(op => `${Object.keys(op)[0]}: ${Object.values(op)[0]}`),
                     Files: files?.map(f => f.fileName ?? 'inline file') ?? [],
+                    Replacements: replacementsFromFiles?.length > 0 ? replacementsFromFiles : undefined,
                     Server: jahiaServer.url,
                     'HTTP Status': response ? `${response.status} ${response.statusText}` : 'pending',
                     Duration: response ? `${response.duration}ms` : 'pending',
@@ -203,6 +231,13 @@ export const runProvisioningScript = ({
         }
 
         logger?.end();
+        if (logger) {
+            const hasFailed = res.status !== 200 ||
+                (Array.isArray(result) && result.some((r: any) => typeof r === 'string' && r.includes('.failed')));
+            const prefix = hasFailed ? '❌ ' : '✅ ';
+            logger.set('message', `${prefix}${scriptSummary} @ ${jahiaServer.url}`);
+        }
+
         return result;
     });
 };

--- a/src/support/provisioning/runProvisioningScript.ts
+++ b/src/support/provisioning/runProvisioningScript.ts
@@ -85,6 +85,42 @@ function isFormFile(script: FormFile | StringDictionary[]): script is FormFile {
     return Boolean((script as FormFile).fileContent || (script as FormFile).fileName);
 }
 
+function getScriptSummary(script: FormFile | StringDictionary[]): string {
+    if (isFormFile(script)) {
+        if (script.fileName) {
+            return script.fileName;
+        }
+
+        if (script.fileContent) {
+            // Parse first operation name from YAML list: "- operationName: ..."
+            const yamlMatch = script.fileContent.match(/^\s*-\s+(\w+)\s*:/m);
+            if (yamlMatch) {
+                return yamlMatch[1];
+            }
+
+            // Parse first operation name from JSON array: [{"operationName": ...}]
+            try {
+                const parsed = JSON.parse(script.fileContent);
+                if (Array.isArray(parsed) && parsed.length > 0) {
+                    const ops = parsed.map((op: Record<string, string>) => Object.keys(op)[0] ?? 'unknown');
+                    return ops.length === 1 ? ops[0] : `[${ops.join(', ')}]`;
+                }
+            } catch {
+                // Not valid JSON, fall through
+            }
+        }
+
+        return 'inline script';
+    }
+
+    if (script.length === 0) {
+        return 'empty script';
+    }
+
+    const ops = script.map(op => Object.keys(op)[0] ?? 'unknown');
+    return ops.length === 1 ? ops[0] : `[${ops.join(', ')}]`;
+}
+
 export const runProvisioningScript = ({
     script,
     files,
@@ -120,13 +156,19 @@ export const runProvisioningScript = ({
             autoEnd: false,
             name: 'runProvisioningScript',
             displayName: 'provScript',
-            message: `Run ${isFormFile(script) && script.fileName ? script.fileName : 'inline script'} towards server: ${jahiaServer.url}`,
+            message: `${getScriptSummary(script)} @ ${jahiaServer.url}`,
             consoleProps: () => {
                 return {
                     Script: script,
-                    Files: files,
-                    Response: response,
-                    Yielded: result
+                    Operations: isFormFile(script) ?
+                        undefined :
+                        script.map(op => `${Object.keys(op)[0]}: ${Object.values(op)[0]}`),
+                    Files: files?.map(f => f.fileName ?? 'inline file') ?? [],
+                    Server: jahiaServer.url,
+                    'HTTP Status': response ? `${response.status} ${response.statusText}` : 'pending',
+                    Duration: response ? `${response.duration}ms` : 'pending',
+                    Result: result,
+                    Response: response
                 };
             }
         });

--- a/src/support/provisioning/runProvisioningScript.ts
+++ b/src/support/provisioning/runProvisioningScript.ts
@@ -233,7 +233,7 @@ export const runProvisioningScript = (paramsOrScript: RunProvisioningScriptParam
         logger?.end();
         if (logger) {
             const hasFailed = res.status !== 200 ||
-                (Array.isArray(result) && result.some((r: any) => typeof r === 'string' && r.includes('.failed')));
+                (Array.isArray(result) && result.some((r: any) => typeof r === 'string' && r.includes('.failed'))); // eslint-disable-line @typescript-eslint/no-explicit-any
             const prefix = hasFailed ? '❌ ' : '✅ ';
             logger.set('message', `${prefix}${scriptSummary} @ ${jahiaServer.url}`);
         }


### PR DESCRIPTION
### Description
Improve cypress logs

Add information to the Groovy and graphQL calls in the logs to match the executed operations
<img width="786" height="334" alt="Screenshot 2026-04-28 at 08 52 02" src="https://github.com/user-attachments/assets/0f9eb428-fc93-4074-832c-34ba8dafb04f" />
Improve the detail of the execution
<img width="961" height="227" alt="Screenshot 2026-04-28 at 08 52 22" src="https://github.com/user-attachments/assets/4038cc4b-7e79-4966-9669-48d6c69963bd" />


### GraphQL
Get the function name executed or the 2 first level of the query
```gql
mutation
    {jcr { addNode { .. } }
``` 
is log as `jcr -> addNode`

The variables used by the query are displayed in the log

### Groovy 
The name of the script executed is log among the replacements used in the script

### Example
**Before**
```logs
  Content History purge test suite
    1) Should only purge content history older than "contentHistoryPurge.retentionInMonths" configured
      cy:command ✔  runProvisioningScript       Run inline script towards server: http://localhost:8080
      cy:command ✔  runProvisioningScript       Run inline script towards server: http://localhost:8080
      cy:command ✔  apolloClient        Create new apollo client
      cy:command ✔  apollo      Execute Graphql Mutation: mutation setProperty($pathOrId: String!, $property: String!, $value: String!, $language: String!){
                        jcr{
                            mutateNode(pathOrId: $pathOrId){
                                mutateProperty(name: $property){
                                    setValue(value: $value, language: $language)
                                }
                            }
                        }
                    }
      cy:command ✔  wrap        {}
          cy:xhr ❖  undefined undefined
      cy:command ✔  apollo      Execute Graphql Mutation: mutation setProperty($pathOrId: String!, $property: String!, $value: String!, $language: String!){
                        jcr{
                            mutateNode(pathOrId: $pathOrId){
                                mutateProperty(name: $property){
                                    setValue(value: $value, language: $language)
                                }
                            }
                        }
                    }
      cy:command ✔  wrap        {}
          cy:xhr ❖  undefined undefined
      cy:command ✔  apollo      Execute Graphql Mutation: mutation setProperty($pathOrId: String!, $property: String!, $value: String!, $language: String!){
                        jcr{
                            mutateNode(pathOrId: $pathOrId){
                                mutateProperty(name: $property){
                                    setValue(value: $value, language: $language)
                                }
                            }
                        }
                    }
      cy:command ✔  wrap        {}
          cy:xhr ❖  undefined undefined
      cy:command ✔  apollo      Execute Graphql Mutation: mutation setProperty($pathOrId: String!, $property: String!, $value: String!, $language: String!){
                        jcr{
                            mutateNode(pathOrId: $pathOrId){
                                mutateProperty(name: $property){
                                    setValue(value: $value, language: $language)
                                }
                            }
                        }
                    }
      cy:command ✔  wrap        {}
          cy:xhr ❖  undefined undefined
      cy:command ✔  apollo      Execute Graphql Mutation: mutation setProperty($pathOrId: String!, $property: String!, $value: String!, $language: String!){
                        jcr{
                            mutateNode(pathOrId: $pathOrId){
                                mutateProperty(name: $property){
                                    setValue(value: $value, language: $language)
                                }
                            }
                        }
                    }
      cy:command ✔  wrap        {}
          cy:xhr ❖  undefined undefined
      cy:command ✔  apollo      Execute Graphql Mutation: mutation setProperty($pathOrId: String!, $property: String!, $value: String!, $language: String!){
                        jcr{
                            mutateNode(pathOrId: $pathOrId){
                                mutateProperty(name: $property){
                                    setValue(value: $value, language: $language)
                                }
                            }
                        }
                    }
      cy:command ✔  wrap        {}
          cy:xhr ❖  undefined undefined
      cy:command ✔  apollo      Execute Graphql Mutation: mutation setProperty($pathOrId: String!, $property: String!, $value: String!, $language: String!){
                        jcr{
                            mutateNode(pathOrId: $pathOrId){
                                mutateProperty(name: $property){
                                    setValue(value: $value, language: $language)
                                }
                            }
                        }
                    }
      cy:command ✔  wrap        {}
          cy:xhr ❖  undefined undefined
      cy:command ✔  apollo      Execute Graphql Mutation: mutation setProperty($pathOrId: String!, $property: String!, $value: String!, $language: String!){
                        jcr{
                            mutateNode(pathOrId: $pathOrId){
                                mutateProperty(name: $property){
                                    setValue(value: $value, language: $language)
                                }
                            }
                        }
                    }
      cy:command ✔  wrap        {}
          cy:xhr ❖  undefined undefined
      cy:command ✔  apollo      Execute Graphql Mutation: mutation setProperty($pathOrId: String!, $property: String!, $value: String!, $language: String!){
                        jcr{
                            mutateNode(pathOrId: $pathOrId){
                                mutateProperty(name: $property){
                                    setValue(value: $value, language: $language)
                                }
                            }
                        }
                    }
      cy:command ✔  wrap        {}
          cy:xhr ❖  undefined undefined
      cy:command ✔  apollo      Execute Graphql Mutation: mutation setProperty($pathOrId: String!, $property: String!, $value: String!, $language: String!){
                        jcr{
                            mutateNode(pathOrId: $pathOrId){
                                mutateProperty(name: $property){
                                    setValue(value: $value, language: $language)
                                }
                            }
                        }
                    }
      cy:command ✔  wrap        {}
          cy:xhr ❖  undefined undefined
      cy:command ✔  apollo      Execute Graphql Query: query getNodeByPath($path: String!, $properties: [String]=[], $language: String="", $childrenTypes: [String] = [], $workspace: Workspace = EDIT ) {
                        jcr (workspace: $workspace){
                            nodeByPath(path: $path) {
                                uuid
                                name
                                properties(names: $properties, language: $language){
                                    name
                                    value
                                    values
                                }
                                primaryNodeType {
                                    name
                                }
                                children(typesFilter: { types: $childrenTypes }) {
                                    nodes {
                                        name
                                        children {
                                            nodes {
                                                properties {
                                                    name
                                                    value
                                         ...
      cy:command ✔  wrap        {}
          cy:xhr ❖  undefined undefined
      cy:command ✔  its .data.jcr.nodeByPath.uuid
      cy:command ✔  waitUntil   {}
      cy:command ✔  runProvisioningScript       Run inline script towards server: http://localhost:8080
      cy:command ✔  runProvisioningScript       Run inline script towards server: http://localhost:8080
      cy:command ✔  runProvisioningScript       Run inline script towards server: http://localhost:8080
      cy:command ✔  runProvisioningScript       Run inline script towards server: http://localhost:8080
      cy:command ✔  runProvisioningScript       Run inline script towards server: http://localhost:8080
      cy:command ✔  runProvisioningScript       Run inline script towards server: http://localhost:8080
      cy:command ✔  runProvisioningScript       Run inline script towards server: http://localhost:8080
      cy:command ✔  runProvisioningScript       Run inline script towards server: http://localhost:8080
      cy:command ✔  runProvisioningScript       Run inline script towards server: http://localhost:8080
      cy:command ✔  runProvisioningScript       Run inline script towards server: http://localhost:8080
      cy:command ✔  runProvisioningScript       Run inline script towards server: http://localhost:8080
      cy:command ✔  runProvisioningScript       Run inline script towards server: http://localhost:8080
      cy:command ✔  runProvisioningScript       Run inline script towards server: http://localhost:8080
      cy:command ✔  runProvisioningScript       Run inline script towards server: http://localhost:8080
      cy:command ✔  runProvisioningScript       Run inline script towards server: http://localhost:8080
      cy:command ✔  runProvisioningScript       Run inline script towards server: http://localhost:8080
      cy:command ✔  runProvisioningScript       Run inline script towards server: http://localhost:8080
      cy:command ✔  runProvisioningScript       Run inline script towards server: http://localhost:8080
      cy:command ✔  runProvisioningScript       Run inline script towards server: http://localhost:8080
      cy:command ✔  runProvisioningScript       Run inline script towards server: http://localhost:8080
      cy:command ✔  runProvisioningScript       Run inline script towards server: http://localhost:8080
      cy:command ✔  runProvisioningScript       Run inline script towards server: http://localhost:8080
      cy:command ✔  runProvisioningScript       Run inline script towards server: http://localhost:8080
      cy:command ✘  then        function(){}
```

**After**
A script result status has been added as a prefix ❌ :white_check_mark: since this sample extracted
```logs
  Content History purge test suite
    1) Should only purge content history older than "contentHistoryPurge.retentionInMonths" configured
      cy:command ✔  executeGroovy       groovy/admin/deleteSite.groovy — {"SITEKEY":"thick-bob"}
      cy:command ✔  executeGroovy       groovy/admin/createSite.groovy — {"SITEKEY":"thick-bob","TEMPLATES_SET":"qa-simpleTemplatesSet","SERVERNAME":"localhost","LOCALE":"en","LANGUAGES":"en"}
       cy:command ✔  apolloClient        Create new apollo client
      cy:command ✔  apollo      [Mutation] setProperty — {"pathOrId":"/sites/dutiful-legend/home","property":"jcr:title","language":"en","value":"update v0"}
        cy:fetch ❖  STUBBED undefined undefined
      cy:command ✔  apollo      [Mutation] setProperty — {"pathOrId":"/sites/dutiful-legend/home","property":"jcr:title","language":"en","value":"update v1"}
        cy:fetch ❖  STUBBED undefined undefined
      cy:command ✔  apollo      [Mutation] setProperty — {"pathOrId":"/sites/dutiful-legend/home","property":"jcr:title","language":"en","value":"update v2"}
        cy:fetch ❖  STUBBED undefined undefined
      cy:command ✔  apollo      [Mutation] setProperty — {"pathOrId":"/sites/dutiful-legend/home","property":"jcr:title","language":"en","value":"update v3"}
        cy:fetch ❖  STUBBED undefined undefined
      cy:command ✔  apollo      [Mutation] setProperty — {"pathOrId":"/sites/dutiful-legend/home","property":"jcr:title","language":"en","value":"update v4"}
        cy:fetch ❖  STUBBED undefined undefined
      cy:command ✔  apollo      [Mutation] setProperty — {"pathOrId":"/sites/dutiful-legend/home","property":"jcr:title","language":"en","value":"update v5"}
        cy:fetch ❖  STUBBED undefined undefined
      cy:command ✔  apollo      [Mutation] setProperty — {"pathOrId":"/sites/dutiful-legend/home","property":"jcr:title","language":"en","value":"update v6"}
        cy:fetch ❖  STUBBED undefined undefined
      cy:command ✔  apollo      [Mutation] setProperty — {"pathOrId":"/sites/dutiful-legend/home","property":"jcr:title","language":"en","value":"update v7"}
        cy:fetch ❖  STUBBED undefined undefined
      cy:command ✔  apollo      [Mutation] setProperty — {"pathOrId":"/sites/dutiful-legend/home","property":"jcr:title","language":"en","value":"update v8"}
        cy:fetch ❖  STUBBED undefined undefined
      cy:command ✔  apollo      [Mutation] setProperty — {"pathOrId":"/sites/dutiful-legend/home","property":"jcr:title","language":"en","value":"update v9"}
        cy:fetch ❖  STUBBED undefined undefined
      cy:command ✔  apollo      [Query] getNodeByPath — {"path":"/sites/dutiful-legend/home/j:translation_en","childrenTypes":[],"workspace":"EDIT"}
        cy:fetch ❖  STUBBED undefined undefined
      cy:command ✔  its .data.jcr.nodeByPath.uuid
      cy:command ✔  waitUntil   {}
      cy:command ✔  executeGroovy       groovy/verifyContentHistoryCount.groovy
      cy:command ✔  executeGroovy       groovy/verifyContentHistoryCount.groovy
      cy:command ✔  executeGroovy       groovy/verifyContentHistoryCount.groovy
      cy:command ✔  executeGroovy       groovy/verifyContentHistoryCount.groovy
      cy:command ✔  executeGroovy       groovy/verifyContentHistoryCount.groovy
      cy:command ✔  executeGroovy       groovy/verifyContentHistoryCount.groovy
      cy:command ✔  executeGroovy       groovy/verifyContentHistoryCount.groovy
      cy:command ✔  executeGroovy       groovy/verifyContentHistoryCount.groovy
      cy:command ✔  executeGroovy       groovy/verifyContentHistoryCount.groovy
      cy:command ✔  executeGroovy       groovy/verifyContentHistoryCount.groovy
      cy:command ✔  executeGroovy       groovy/verifyContentHistoryCount.groovy
      cy:command ✔  executeGroovy       groovy/verifyContentHistoryCount.groovy
      cy:command ✔  executeGroovy       groovy/verifyContentHistoryCount.groovy
      cy:command ✔  executeGroovy       groovy/verifyContentHistoryCount.groovy
      cy:command ✔  executeGroovy       groovy/verifyContentHistoryCount.groovy
      cy:command ✔  executeGroovy       groovy/verifyContentHistoryCount.groovy
      cy:command ✔  executeGroovy       groovy/verifyContentHistoryCount.groovy
      cy:command ✔  executeGroovy       groovy/verifyContentHistoryCount.groovy
      cy:command ✔  executeGroovy       groovy/verifyContentHistoryCount.groovy
      cy:command ✔  executeGroovy       groovy/verifyContentHistoryCount.groovy
      cy:command ✔  executeGroovy       groovy/verifyContentHistoryCount.groovy
      cy:command ✔  executeGroovy       groovy/verifyContentHistoryCount.groovy
      cy:command ✘  then        function(){}
```
