### PR TITLE
fix: use default Jahia ref from ENV

### DIFF
--- a/.chachalog/UHu-BqU8.md
+++ b/.chachalog/UHu-BqU8.md
@@ -1,0 +1,5 @@
+---
+"@jahia/cypress": patch
+---
+
+Use default Jahia ref. while fetching version; fail safe when version can't be fetched.

--- a/src/support/modSince.ts
+++ b/src/support/modSince.ts
@@ -90,12 +90,19 @@ const skipReason = (scope: string, title: string, required: string, current?: st
  * and caches the result in `Cypress.env(JAHIA_VERSION_ENV_VAR)`.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const initializeVersionSupport = (): Cypress.Chainable<any> =>
-    getJahiaVersion().then(jahiaVersion => {
-        const version = jahiaVersion.release.replace('-SNAPSHOT', '');
+export const initializeVersionSupport = (): Cypress.Chainable<any> => {
+    const cachedVersion = Cypress.env(JAHIA_VERSION_ENV_VAR);
+
+    if (typeof cachedVersion === 'string' && cachedVersion.trim() !== '') {
+        return cy.wrap(cachedVersion, {log: false});
+    }
+
+    return getJahiaVersion().then(jahiaVersion => {
+        const version = jahiaVersion?.release?.replace('-SNAPSHOT', '') || '0.0.0.1';
         Cypress.env(JAHIA_VERSION_ENV_VAR, version);
         return version;
     });
+};
 
 /**
  * Attaches `.since()` to `it`, `it.only`, `it.skip`, `describe`, `describe.only`,

--- a/src/utils/JahiaPlatformHelper.ts
+++ b/src/utils/JahiaPlatformHelper.ts
@@ -1,9 +1,20 @@
+/**
+ * Fetches the Jahia version using a GraphQL query.
+ * @returns Cypress.Chainable that resolves to the Jahia version record (e.g., release: "8.0.0", ...).
+ * @note In rare cases tests might override baseUrl (e.g. when Jahia is configured with custom context path,
+ *       but spec want to use just a host, without the context path), e.g.:
+ *       it('Crawl pages', {baseUrl: serverURL.origin}, () => { ... })
+ *       In such case(s) this call will fail because the GraphQL endpoint will not be found at the root of the host.
+ *       To prevent such failure, we ensure GraphQL client uses full Jahia url as configured in env variable.
+ */
 export const getJahiaVersion = (): Cypress.Chainable => {
-    return cy.apollo({
-        fetchPolicy: 'no-cache',
-        queryFile: 'graphql/jcr/query/getJahiaVersion.graphql'
-    }).then(result => {
-        return result?.data?.admin.jahia.version;
+    return cy.apolloClient({url: Cypress.env('JAHIA_URL') || Cypress.config().baseUrl}).then(() => {
+        return cy.apollo({
+            fetchPolicy: 'no-cache',
+            queryFile: 'graphql/jcr/query/getJahiaVersion.graphql'
+        }).then(result => {
+            return result?.data?.admin.jahia.version;
+        });
     });
 };
 

--- a/tests/cypress/e2e/modSince.spec.ts
+++ b/tests/cypress/e2e/modSince.spec.ts
@@ -1,11 +1,19 @@
 import '../../../src/support/apollo/apollo';
+import '../../../src/support/apollo/apolloClient';
 import {modSince, initializeVersionSupport, JAHIA_VERSION_ENV_VAR} from '../../../src/support/modSince';
+
+type ItSinceCall = (requiredVersion: string, title: string, fn?: (...args: unknown[]) => unknown) => Mocha.Test;
+type DescribeSinceCall = (requiredVersion: string, title: string, fn: (this: Mocha.Suite) => void) => Mocha.Suite;
 
 // Enable version gating
 modSince.enable();
 
 // Stub apollo command
-Cypress.Commands.add('apollo', {prevSubject: 'optional'}, () => {
+Cypress.Commands.add('apolloClient', (() => {
+    return cy.wrap({} as unknown);
+}) as Cypress.CommandFn<'apolloClient'>);
+
+Cypress.Commands.add('apollo', (() => {
     return cy.wrap({
         data: {
             admin: {
@@ -17,7 +25,7 @@ Cypress.Commands.add('apollo', {prevSubject: 'optional'}, () => {
             }
         }
     });
-});
+}) as Cypress.CommandFn<'apollo'>);
 
 describe('itSince support', () => {
     describe('registration', () => {
@@ -38,7 +46,7 @@ describe('itSince support', () => {
 
         it('throws clear error when it.since args are swapped', () => {
             expect(() => {
-                (it.since as unknown as (requiredVersion: string, title: string, fn?: Mocha.Func) => Mocha.Test)(
+                (it.since as unknown as ItSinceCall)(
                     'my test title',
                     '8.2.0',
                     () => {
@@ -100,7 +108,7 @@ describe('itSince support', () => {
         let compatItRan = false;
         let compatDescribeRan = false;
 
-        const compatIt = (it.skip as unknown as (requiredVersion: string, title: string, fn?: Mocha.Func) => Mocha.Test)(
+        const compatIt = (it.skip as unknown as ItSinceCall)(
             '8.3.5.0',
             compatItTitle,
             () => {
@@ -108,7 +116,7 @@ describe('itSince support', () => {
             }
         );
 
-        const compatDescribe = (describe.skip as unknown as (requiredVersion: string, title: string, fn: (this: Mocha.Suite) => void) => Mocha.Suite)(
+        const compatDescribe = (describe.skip as unknown as DescribeSinceCall)(
             '8.3.5.0',
             compatDescribeTitle,
             () => {
@@ -136,6 +144,26 @@ describe('itSince support', () => {
     });
 
     describe('version initialization', () => {
+        beforeEach(() => {
+            Cypress.env(JAHIA_VERSION_ENV_VAR, '');
+        });
+
+        it('returns cached env version without fetching from GraphQL', () => {
+            Cypress.env(JAHIA_VERSION_ENV_VAR, '9.9.9');
+            // Use `any` here because custom commands are not part of Cypress's typed EventEmitter keys.
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const cyAny = cy as any;
+            const apolloClientSpy = cy.spy(cyAny, 'apolloClient').as('apolloClientSpy');
+            const apolloSpy = cy.spy(cyAny, 'apollo').as('apolloSpy');
+
+            return initializeVersionSupport().then(version => {
+                expect(version).to.equal('9.9.9');
+                expect(Cypress.env(JAHIA_VERSION_ENV_VAR)).to.equal('9.9.9');
+                expect(apolloClientSpy).to.not.have.been.called;
+                expect(apolloSpy).to.not.have.been.called;
+            });
+        });
+
         it('stores normalized Jahia version in Cypress.env', () => {
             return initializeVersionSupport().then(version => {
                 expect(version).to.equal('8.2.0');


### PR DESCRIPTION
Use default Jahia ref. while fetching version; fail safe when version can't be fetched.
