### PR TITLE
feat: cypress logging to files and terminal

### DIFF
--- a/.chachalog/xWKBrUUg.md
+++ b/.chachalog/xWKBrUUg.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/cypress": minor
+---
+
+Optional cypress logging to per-spec log files and terminal (#233)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
-
 <a href="https://www.jahia.com/">
     <img src="https://www.jahia.com/modules/jahiacom-templates/images/jahia-3x.png" alt="Jahia logo" title="Jahia" align="right" height="60" />
 </a>
 
-@jahia/cypress
-======================
+# @jahia/cypress
 
 ## Commands
 
@@ -28,9 +26,9 @@
 
 ## Page / component objects
 
-In Page Object Model, a set of object is provided to handle known and reused web elements. 
-These page objects provide method to handle interactions with these web elements. 
-Web elements can be simple HTML elements, more complex UI components or full pages. 
+In Page Object Model, a set of object is provided to handle known and reused web elements.
+These page objects provide method to handle interactions with these web elements.
+Web elements can be simple HTML elements, more complex UI components or full pages.
 
 This framework does not come with predefined page objects, as they should be provided by the modules which define them.
 TODO: Moonstone page object are defined here, but could be moved to moonstone
@@ -39,8 +37,8 @@ TODO: Moonstone page object are defined here, but could be moved to moonstone
 
 #### Components
 
-Page object representing a component extends `baseComponent`. 
-Creating a page object will enqueue a command looking for the corresponding DOM element. 
+Page object representing a component extends `baseComponent`.
+Creating a page object will enqueue a command looking for the corresponding DOM element.
 An alias to this element will be stored in the object.
 
 Page object can provide accessors to other page object, and methods that will enqueue other cypress commands and assertions.
@@ -63,7 +61,6 @@ primaryNav.listItems().expect('...') // Check primary nav content
 primaryNav.select('jcontent')        // Select the corresponding item and click on it
 ```
 
-
 ```typescript
 let jcontent = JContent.visit("digitall", "en", "pages");
 jcontent.select('content-folders')
@@ -75,13 +72,13 @@ m.select('edit')
 
 Add `@jahia/cypress` to your project.
 
-Add cypress commands and support : in support/index.js, adds : 
+Add cypress commands and support : in support/index.js, adds :
 
 ```js
 require('@jahia/cypress/dist/support/registerSupport').registerSupport()
 ```
 
-Add typings in your tsconfig.json : 
+Add typings in your tsconfig.json :
 
 ```json
 {
@@ -108,10 +105,12 @@ module.exports = (on, config) => {
 ## Version-gated tests
 
 After enabling `modSince` via `registerSupport`, you can gate tests and suites by Jahia version with:
+
 - `it.since(requiredVersion, title, testFn)`
 - `describe.since(requiredVersion, title, suiteFn)`
 
 Modifiers are supported as well:
+
 - `it.only.since(...)`, `describe.only.since(...)`
 - `it.skip.since(...)`, `describe.skip.since(...)`
 
@@ -120,6 +119,7 @@ Modifiers are supported as well:
 `it.skip.since(...)` and `describe.skip.since(...)` are always skipped (same behavior as Cypress `skip`, with a version argument for consistency).
 
 Jahia version is fetched in a root `before()` hook and stored in environment variable `CYPRESS_JAHIA_VERSION`.
+
 ```typescript
 it.since('8.2.0', 'shows the new dashboard widget', () => {
     // test body
@@ -157,13 +157,20 @@ describe.skip.since('8.2.0', 'always skipped version-gated suite', () => {
 ## Internal Auxiliary Libraries
 
 ### Extended Logger Module
+
 Helper utility designed to enhance Cypress test logging capabilities by providing structured log levels and decorating log messages with appropriate severity indicators. It enables developers to create more organized and filterable test output by categorizing log messages into different levels. Read more [here](./docs/extended-logger.md).
 
 ### JavaScript Errors Logger
+
 Comprehensive monitoring and reporting module for JavaScript errors and warnings in Cypress tests. It provides automated detection, collection, and reporting of console errors and warnings that occur during test execution, helping maintain code quality and identify issues early in the development process. Read more [here](./docs/js-errors-logger.md).
 
 ### jFaker - Fake Data Generation Module
+
 Flexible fake data generation utility for Cypress testing that combines the power of Faker.js with security-focused injection payload generation. It provides a unified API to generate both realistic test data and security testing payloads (XSS, SQL injection, etc.) through a dynamic proxy-based interface. Read more [here](./docs/jfaker.md).
+
+### Cypress logs
+
+Centralized [cypress-terminal-report](https://github.com/archfz/cypress-terminal-report) setup: writes command/console logs to files (and/or the terminal) so failures can be diagnosed from CI logs. A single `registerLogsPrinter(on, config)` call in the plugins file enables both the printer and the log collector — the collector self-detects whether the printer is enabled, so the two can't drift out of sync. Read more [here](./docs/cypress-logs.md).
 
 ## Open-Source
 

--- a/docs/cypress-logs.md
+++ b/docs/cypress-logs.md
@@ -1,0 +1,132 @@
+# Terminal/Files Logs Reporter (cypress-terminal-report integration)
+
+## Overview
+
+[cypress-terminal-report](https://github.com/archfz/cypress-terminal-report) collects Cypress
+command/console logs and writes them to files (and/or prints them to the terminal) so failures can
+be diagnosed from CI logs without re-running a headed browser. Historically, every consumer repo
+(e.g. `jahia-ee/docker-tests`, etc.) copy-pasted its own setup for this into their `cypress/plugins/index.js` and
+`cypress/support/e2e.js`. `src/support/terminalReport.ts` centralizes that setup in `@jahia/cypress`
+so consumers just call a function instead of maintaining the configuration themselves.
+
+## Architecture: two processes, two halves
+
+cypress-terminal-report is split into two independent pieces that run in **two different OS
+processes**, and this shows up directly in how this module is structured:
+
+| | Collector | Printer |
+|---|---|---|
+| Runs in | Browser / spec-runner process | Node.js plugin process |
+| Installed by | `installLogsCollector` (cypress-terminal-report) | `installLogsPrinter` (cypress-terminal-report) |
+| Wrapped by | `registerLogsCollector` | `registerLogsPrinter` |
+| Called from | `registerSupport()` (`support/e2e.js`) | Explicitly, in `setupNodeEvents(on, config)` (`plugins/index.js`) |
+| Job | Gathers cy commands, console logs, etc. during a test | Writes/prints the collected logs once a run finishes |
+| Talks via | `cy.task('ctrLogMessages'/'ctrLogFiles', ...)` | Registers those same task names via `on('task', {...})` |
+
+**Why the printer is registered explicitly, not auto-wired into `registerPlugins`:** `registerPlugins`
+is called by every consumer repo today, most of which don't use file-based log printing. Auto-wiring
+the printer into it would silently turn on log-file writing for every repo the moment they upgraded
+`@jahia/cypress` — an implicit behavior change with no opt-out that nobody asked for. Requiring an
+explicit `registerLogsPrinter(on, config)` call keeps `registerPlugins` (and its diff) untouched and
+makes the log-printing behavior opt-in and visible at the call site.
+
+**Why the collector doesn't need the same explicit call:** unlike the printer, the collector is
+*derived* from whether the printer is enabled (see "Why the collector self-detects" below) — so
+`registerSupport()` can stay a plain, unconditional call with no new required argument.
+
+## Why the collector self-detects instead of taking its own on/off flag
+
+The critical constraint: **the collector must never run without the printer.** The collector calls
+`cy.task('ctrLogMessages', ...)` after each command; that task handler is only registered by
+`installLogsPrinter`. If the collector runs and the printer wasn't installed, `cy.task()` fails with
+"no task was registered by that name" — which fails the Cypress command chain and **breaks every
+test**, not just silently no-ops.
+
+An earlier iteration of this module gave the collector its own independent on/off switch
+(`registerSupport({logsCollector: true | false | options})`). That's fragile: it requires consumers
+to keep two switches (printer enabled in the plugins file, collector enabled in the support file) in
+sync by hand, in two different files, with no compiler or runtime check tying them together. Get it
+wrong in one direction (`printer: on, collector: off`) and logging silently doesn't happen; get it
+wrong in the other (`printer: off, collector: on`) and every test breaks.
+
+**Solution:** `registerLogsPrinter` marks itself as enabled, and `registerLogsCollector` checks that
+marker instead of taking its own explicit flag. This makes the two impossible to get out of sync —
+there is exactly one switch (whether `registerLogsPrinter` was called), not two.
+
+### How the marker crosses the process boundary
+
+The plugin process (where `registerLogsPrinter` runs) and the browser process (where
+`registerLogsCollector` runs) don't share memory — there is no `Cypress` global in the Node process,
+and no `config` object in the browser. The only channel between them is Cypress's own config
+resolution: whatever a plugins file's `setupNodeEvents(on, config)` mutates on `config.env` and
+returns becomes readable in the browser via `Cypress.env(key)`. This is the same mechanism
+`registerPlugins`'s `env.ts` already uses for `config.env.JAHIA_URL`, etc.
+
+- `enableLogsPrinter(config)` — __Node/plugins side.__ Sets `config.env.JAHIA_HOOKS_TERMINAL_LOGGER_ENABLED = true`.
+   Called from `registerLogsPrinter`.
+- `isLogsPrinterEnabled()` — __browser/support side.__ Reads `Cypress.env('JAHIA_HOOKS_TERMINAL_LOGGER_ENABLED')`.
+   Called from `registerLogsCollector`, which no-ops if this is falsy.
+
+This works reliably because of Cypress's own lifecycle ordering: `setupNodeEvents` (Node process)
+always runs once at startup, before the browser launches; `registerSupport()` (browser process) then
+runs once per spec file, before that spec's tests. So by the time any collector code executes, the
+printer (if enabled) has already set the flag — there's no race condition to guard against.
+
+## Printer and Collector location
+
+`logsPrinter` and  `logsCollector` are two separate files (`src/plugins/logsPrinter.ts` and `src/support/logsCollector.ts`) to mirror `server` vs `client` logic and avoid confusion while calling server-side function from the file, located in client-side folder.
+
+## Usage
+
+Enabling logging is a single call in the plugins file — nothing needs to change in the support file:
+
+```js
+// plugins/index.js
+setupNodeEvents(on, config) {
+    require('@jahia/cypress/dist/plugins/registerPlugins').registerPlugins(on, config);
+    require('@jahia/cypress/dist/plugins/logsPrinter').registerLogsPrinter(on, config);
+    return config;
+}
+```
+
+```js
+// support/e2e.js — unchanged; the collector activates automatically once the printer is enabled
+require('@jahia/cypress/dist/support/registerSupport').registerSupport();
+```
+
+If `registerLogsPrinter` is never called, `registerSupport()` remains a no-op for logging — nothing
+to enable, nothing that can break.
+**Keep in mind:** if there is existing setup for the `cypress-terminal-report` in your repo - it might need to be cleaned up along with removing `cypress-terminal-report` from `package.json`
+
+### Overriding options
+
+```js
+// Printer: override any cypress-terminal-report PluginOptions
+registerLogsPrinter(on, config, {printLogsToFile: 'onFail'});
+
+// Collector: override any cypress-terminal-report SupportOptions, via registerSupport
+registerSupport({logsCollector: {collectTypes: ['cy:command', 'cy:xhr']}});
+```
+
+## API Reference
+
+| Export | Where called from | Description |
+|---|---|---|
+| `registerLogsPrinter(on, config, options?)` | Plugins file, `setupNodeEvents` | Installs the printer with Jahia's defaults (txt logs under `results/logs/`, console output on failure only); marks the printer as enabled. |
+| `registerLogsCollector(options?)` | Automatically, from `registerSupport` | Installs the collector with Jahia's defaults, but only if `registerLogsPrinter` was called — otherwise a no-op. |
+
+### Defaults
+
+**Printer** (`registerLogsPrinter`):
+
+- `outputRoot`: `<projectRoot>/results/logs/`
+- `specRoot`: `cypress/e2e`
+- `outputTarget`: `{'.|log': 'txt'}`
+- `printLogsToConsole`: `'onFail'`
+- `printLogsToFile`: `'always'`
+- `includeSuccessfulHookLogs`: `true`
+
+**Collector** (`registerLogsCollector`):
+
+- `enableExtendedCollector`: `true`
+- `collectTypes`: `['cons:log', 'cons:info', 'cons:error', 'cy:log', 'cy:xhr', 'cy:fetch', 'cy:request', 'cy:intercept', 'cy:command']`

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@faker-js/faker": "^10.3.0",
     "compare-versions": "^6.1.1",
     "cypress-real-events": "^1.11.0",
+    "cypress-terminal-report": "^7.3.3",
     "graphql": "^15.5.0",
     "graphql-tag": "^2.11.0"
   },

--- a/src/plugins/logsPrinter.ts
+++ b/src/plugins/logsPrinter.ts
@@ -1,0 +1,58 @@
+import installLogsPrinter from 'cypress-terminal-report/src/installLogsPrinter';
+import type {PluginOptions} from 'cypress-terminal-report/src/installLogsPrinter.types';
+import {envVarLogsPrinterEnabled} from '../support/logsCollector';
+
+/**
+ *  Jahia's default cypress-terminal-report setup (https://github.com/archfz/cypress-terminal-report).
+ *  Node/plugins-side half of the setup, which registers the `ctrLogMessages`/`ctrLogFiles` task handlers
+ *  and writes the collected logs to files (and/or prints them to the terminal) once a run finishes.
+ *
+ *  see support/logsCollector.ts for the complementary collector-side half of this setup, which gathers
+ *  cy commands, console logs, etc., and sends them to the Node process via `cy.task('ctrLogMessages'/'ctrLogFiles', ...)`.
+ */
+
+// See support/logsCollector.ts for the complementary collector-side half of this setup.
+// This env var is set in the Node/plugins process and read back in the browser/support process, so
+// the collector knows whether the printer was enabled (and thus whether it should enable itself).
+// const envVarLogsPrinterEnabled = 'JAHIA_HOOKS_TERMINAL_LOGGER_ENABLED';
+
+/**
+ * Marks the printer as enabled, by setting a `config.env` flag that `envVarLogsPrinterEnabled` reads
+ * back on the browser side. Must run in the Node/plugins process, since that's the only place
+ * `config` (and its `env` object shared with the browser via `Cypress.env()`) is available.
+ * @param config - the Cypress plugin config passed to `registerLogsPrinter`.
+ */
+function enableLogsPrinter(config: Cypress.PluginConfigOptions): void {
+    config.env[envVarLogsPrinterEnabled] = true;
+}
+
+/**
+ * Installs cypress-terminal-report's printer (Node/plugins side) with Jahia's default logging setup
+ * (plain text log files under `results/logs/`, printed to console on failure only), and marks
+ * itself as enabled so `registerLogsCollector`/`registerSupport` know to enable the collector too.
+ * Must be called from the plugins file's `setupNodeEvents(on, config)` — see the module doc above.
+ * Pass `options` to override any of the defaults.
+ *
+ * @example
+ * registerLogsPrinter(on, config); // defaults
+ * registerLogsPrinter(on, config, {printLogsToFile: 'onFail'}); // override an option
+ */
+export const registerLogsPrinter = (
+    on: Cypress.PluginEvents,
+    config: Cypress.PluginConfigOptions,
+    options: PluginOptions = {}
+): void => {
+    enableLogsPrinter(config);
+
+    installLogsPrinter(on, {
+        outputRoot: config.projectRoot + '/results/logs/',
+        specRoot: 'cypress/e2e',
+        outputTarget: {
+            '.|log': 'txt'
+        },
+        printLogsToConsole: 'onFail',
+        printLogsToFile: 'always',
+        includeSuccessfulHookLogs: true,
+        ...options
+    });
+};

--- a/src/support/index.ts
+++ b/src/support/index.ts
@@ -9,3 +9,4 @@ export * from './jfaker';
 export * from './browserHelper';
 export * from './modSince';
 export * from './contextReporter';
+export * from './logsCollector';

--- a/src/support/logsCollector.ts
+++ b/src/support/logsCollector.ts
@@ -1,0 +1,75 @@
+import installLogsCollector from 'cypress-terminal-report/src/installLogsCollector';
+import type {SupportOptions} from 'cypress-terminal-report/src/installLogsCollector.types';
+
+/**
+ * Jahia's default cypress-terminal-report setup (https://github.com/archfz/cypress-terminal-report).
+ *
+ * cypress-terminal-report has two independent halves that run in two different processes, and
+ * BOTH must be enabled together or neither should be:
+ * - The collector (browser/spec-runner side) gathers cy commands, console logs, etc., and sends
+ *   them to the Node process via `cy.task('ctrLogMessages'/'ctrLogFiles', ...)`.
+ * - The printer (Node plugin process) registers the `ctrLogMessages`/`ctrLogFiles` task handlers
+ *   and writes the collected logs to files (and/or prints them to the terminal) once a run finishes.
+ *
+ * If the collector runs without the printer registering those tasks, `cy.task()` fails with
+ * "no task registered" and breaks every test. Rather than requiring consumers to flip two separate
+ * switches in sync, `registerLogsPrinter` sets a `config.env` flag when it runs, and
+ * `registerLogsCollector`/`registerSupport` only turn the collector on if that flag is present.
+ * Since `setupNodeEvents` (Node process) always runs before any spec's support file (browser
+ * process) — see the "which runs first" note this API was designed around — the flag is always
+ * set in time. Practically, this means enabling logging is a single call in the plugins file:
+ *
+ * ```js
+ * // plugins/index.js — this alone turns on BOTH the printer and (automatically) the collector
+ * setupNodeEvents(on, config) {
+ *     require('@jahia/cypress/dist/plugins/registerPlugins').registerPlugins(on, config);
+ *     require('@jahia/cypress/dist/plugins/logsPrinter').registerLogsPrinter(on, config);
+ *     // or, to override printer options: registerLogsPrinter(on, config, {printLogsToFile: 'onFail'});
+ *     return config;
+ * }
+ *
+ * // support/e2e.js — registerSupport() needs no changes; the collector activates automatically.
+ * // Pass `logsCollector` only if you want to override the collector's own options:
+ * require('@jahia/cypress/dist/support/registerSupport').registerSupport({
+ *     logsCollector: {collectTypes: ['cy:command', 'cy:xhr']}
+ * });
+ * ```
+ *
+ * If `registerLogsPrinter` is never called, `registerSupport()` stays a no-op for logging — nothing
+ * to enable, nothing that can break.
+ */
+
+export const envVarLogsPrinterEnabled = 'JAHIA_HOOKS_TERMINAL_LOGGER_ENABLED';
+
+/**
+ * Checks whether `registerLogsPrinter` marked itself as enabled via `enableLogsPrinter`. Only
+ * meaningful in the browser/support context, where `Cypress.env()` reflects whatever the
+ * Node/plugins process set.
+ * @returns {boolean} true if the printer is enabled, false otherwise.
+ */
+function isLogsPrinterEnabled(): boolean {
+    return Boolean(Cypress.env(envVarLogsPrinterEnabled));
+}
+
+/**
+ * Installs cypress-terminal-report's collector (browser/support side) with Jahia's default logging
+ * setup, but only if `registerLogsPrinter` was called in the plugins file (checked via
+ * `isLogsPrinterEnabled`) — otherwise this is a no-op, since running the collector without the
+ * printer would break every test with a "no task registered" error (see module doc above).
+ * Called automatically from `registerSupport`. Pass `options` to override any of the defaults.
+ *
+ * @example
+ * registerLogsCollector(); // defaults, only if the printer is enabled
+ * registerLogsCollector({collectTypes: ['cy:command', 'cy:xhr']}); // override an option
+ */
+export const registerLogsCollector = (options: SupportOptions = {}): void => {
+    if (!isLogsPrinterEnabled()) {
+        return;
+    }
+
+    installLogsCollector({
+        enableExtendedCollector: true,
+        collectTypes: ['cons:log', 'cons:info', 'cons:error', 'cy:log', 'cy:xhr', 'cy:fetch', 'cy:request', 'cy:intercept', 'cy:command'],
+        ...options
+    });
+};

--- a/src/support/registerSupport.ts
+++ b/src/support/registerSupport.ts
@@ -8,8 +8,30 @@ import {step} from './testStep';
 import {jfaker} from './jfaker';
 import {modSince} from './modSince';
 import {collect as contextCollector} from './contextReporter';
+import {registerLogsCollector} from './logsCollector';
+import type {SupportOptions} from 'cypress-terminal-report/src/installLogsCollector.types';
 
-export const registerSupport = (): void => {
+export interface RegisterSupportOptions {
+    /**
+     * Options forwarded to cypress-terminal-report's collector. Only takes effect if the plugins
+     * file also called `registerLogsPrinter` (see `./logsCollector`) — otherwise the collector
+     * stays disabled automatically, since running it without the printer would break every test.
+     */
+    logsCollector?: SupportOptions;
+}
+
+/**
+ * Registers Jahia's shared Cypress commands and support-side setup (apollo, provisioning, login,
+ * fixtures, etc.). Also wires in cypress-terminal-report's log collector (see `./logsCollector`),
+ * which self-activates only when the plugins file enabled the printer.
+ *
+ * @example
+ * registerSupport(); // defaults; log collector activates only if registerLogsPrinter was called
+ * registerSupport({logsCollector: {collectTypes: ['cy:command']}}); // override collector options
+ */
+export const registerSupport = (registerOptions: RegisterSupportOptions = {}): void => {
+    registerLogsCollector(registerOptions.logsCollector);
+
     Cypress.Commands.add('apolloClient', apolloClient);
     Cypress.Commands.add('apollo', {prevSubject: 'optional'}, apollo);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1417,6 +1417,7 @@ __metadata:
     cross-fetch: "npm:^3.1.5"
     cypress: "npm:^12.17.4"
     cypress-real-events: "npm:^1.11.0"
+    cypress-terminal-report: "npm:^7.3.3"
     cypress-wait-until: "npm:^3.0.2"
     eslint: "npm:^8.57.1"
     eslint-plugin-cypress: "npm:^2.15.2"
@@ -2592,6 +2593,19 @@ __metadata:
   peerDependencies:
     cypress: ^4.x || ^5.x || ^6.x || ^7.x || ^8.x || ^9.x || ^10.x || ^11.x || ^12.x || ^13.x || ^14.x || ^15.x
   checksum: 10c0/effb064bed46c8f059ff0b4d315e3cf0a23e2d411948431475ef1b939db8cc1624a7ca033a57dd8d8e3a297240deb298423464bf12a441330d449a06060ba423
+  languageName: node
+  linkType: hard
+
+"cypress-terminal-report@npm:^7.3.3":
+  version: 7.3.3
+  resolution: "cypress-terminal-report@npm:7.3.3"
+  dependencies:
+    chalk: "npm:^4.0.0"
+    compare-versions: "npm:^6.1.1"
+    superstruct: "npm:0.14.2"
+  peerDependencies:
+    cypress: ">=10.0.0"
+  checksum: 10c0/afd2976c26e5a92499c3b00b0f223764a9029c4ec57da99a4efa737cf1b9468541281c59252c18fc93e4ad2672d86aa607e046e8ccaddd12c94166444f49aded
   languageName: node
   linkType: hard
 
@@ -5901,6 +5915,13 @@ __metadata:
   version: 3.1.1
   resolution: "strip-json-comments@npm:3.1.1"
   checksum: 10c0/9681a6257b925a7fa0f285851c0e613cc934a50661fa7bb41ca9cbbff89686bb4a0ee366e6ecedc4daafd01e83eee0720111ab294366fe7c185e935475ebcecd
+  languageName: node
+  linkType: hard
+
+"superstruct@npm:0.14.2":
+  version: 0.14.2
+  resolution: "superstruct@npm:0.14.2"
+  checksum: 10c0/e5518f6701524fb8cbae504a84dc9c304bf3fe01616230a5eb4e14af9bfc4e3518b94bfe457e57a5d1b99a2b54f82881b4a39e0b266caa6053f84aa294613b94
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
_Once turned ON_ for the repo, stores cypress per-spec log files (containing same information which can be seen while using cypress UI). 
<img width="530" height="763" alt="image" src="https://github.com/user-attachments/assets/b9b0da75-c8b2-4ec6-84c9-4ee0badacd3a" />

Example: [base.cy.log.txt](https://github.com/user-attachments/files/30195656/base.cy.log.txt)
Logs for one of recent builds (vpn required): https://qa.jahia.com/artifacts-ci/delete-on-2026-08-19_Jahia_jahia-ee_jahia-ee-dc-mysql-80yml-2984_29738868948_1/artifacts/results/logs/

These logs can be extended/improved/decorated going forward according to customer needs.

