### PR TITLE
chore: postinstall action for yarn berry (to handle git-sourced dependencies)

### DIFF
--- a/.chachalog/ozqwClxt.md
+++ b/.chachalog/ozqwClxt.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/cypress": patch
+---
+
+Postinstall action for yarn berry (to handle git-sourced dependencies in modern yarn versions) (#236)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "build": "tsc",
     "lint": "eslint src -c .eslintrc.json --ext .ts --max-warnings=0",
-    "prepare": "npm run build"
+    "prepare": "npm run build",
+    "postinstall": "npm run build"
   },
   "bin": {
     "ci.build": "./ci.build.sh",


### PR DESCRIPTION

Similar to https://github.com/Jahia/jahia-cypress/pull/235 (which handles git-sourced dependencies for yarn 1.X) we have to support the same for modern yarn berry.