### PR TITLE
chore: revert postinstall cmd

### DIFF
--- a/.chachalog/m_AmZjRe.md
+++ b/.chachalog/m_AmZjRe.md
@@ -1,6 +1,0 @@
----
-# Allowed version bumps: patch, minor, major
-"@jahia/cypress": patch
----
-
-Add prepare script to allow git-sourced dependencies usage (#235)

--- a/.chachalog/ozqwClxt.md
+++ b/.chachalog/ozqwClxt.md
@@ -1,6 +1,0 @@
----
-# Allowed version bumps: patch, minor, major
-"@jahia/cypress": patch
----
-
-Postinstall action for yarn berry (to handle git-sourced dependencies in modern yarn versions) (#236)

--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
   "version": "8.2.1",
   "scripts": {
     "build": "tsc",
-    "lint": "eslint src -c .eslintrc.json --ext .ts --max-warnings=0",
-    "prepare": "npm run build",
-    "postinstall": "npm run build"
+    "lint": "eslint src -c .eslintrc.json --ext .ts --max-warnings=0"
   },
   "bin": {
     "ci.build": "./ci.build.sh",


### PR DESCRIPTION
Due to Jahia Cypress container build peculiarities, these cmds don't bring any benefits.