### PR TITLE
fix: give the packaged-fixture fallback the project command timeout

### DIFF
--- a/.chachalog/oVHUhtyi.md
+++ b/.chachalog/oVHUhtyi.md
@@ -3,4 +3,4 @@
 "@jahia/cypress": patch
 ---
 
-Fixed intermittent test failures when reading a fixture that the project does not provide. These reads now use the project's `defaultCommandTimeout` instead of a shorter fixed timeout, so a loaded machine no longer fails the test.
+Fixed intermittent test failures when reading a fixture that the project does not provide. These reads now use the project's `defaultCommandTimeout` instead of a shorter fixed timeout, so a loaded machine no longer fails the test. (#242)

--- a/.chachalog/oVHUhtyi.md
+++ b/.chachalog/oVHUhtyi.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/cypress": patch
+---
+
+Fixed intermittent test failures when reading a fixture that the project does not provide. These reads now use the project's `defaultCommandTimeout` instead of a shorter fixed timeout, so a loaded machine no longer fails the test.

--- a/src/support/fixture.ts
+++ b/src/support/fixture.ts
@@ -1,5 +1,7 @@
 import Chainable = Cypress.Chainable;
 
+const PACKAGED_FIXTURES_PATH = './node_modules/@jahia/cypress/fixtures/';
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const fixture = function (originalCommand: ((...args: any[]) => any), fixtureParam: string, ...args: any[]): Chainable<any> {
     return cy.wrap({}, {log: false}).then(() => {
@@ -9,17 +11,21 @@ export const fixture = function (originalCommand: ((...args: any[]) => any), fix
             return null;
         });
     }).then(file => {
-        if (!file) {
-            let encoding;
-            if (typeof args[0] === 'string') {
-                encoding = args[0];
-            }
-
-            try {
-                cy.readFile('./node_modules/@jahia/cypress/fixtures/' + fixtureParam, encoding, {log: false, timeout: 2000});
-            } catch (e) {
-                console.log(e);
-            }
+        if (file) {
+            return file;
         }
+
+        let encoding;
+        if (typeof args[0] === 'string') {
+            encoding = args[0];
+        }
+
+        // The project has no fixture of that name, so read the copy shipped with this library.
+        // This read takes the project's defaultCommandTimeout: a private budget of a few hundred
+        // milliseconds made it the first command to fail on a loaded machine, which turned a slow
+        // disk into a failed test. A failure here is not caught on purpose. cy.readFile() queues a
+        // command instead of running inline, so a try/catch around it never sees the error, and a
+        // fixture the caller cannot read is a failure in every case.
+        return cy.readFile(PACKAGED_FIXTURES_PATH + fixtureParam, encoding, {log: false});
     });
 };

--- a/src/support/fixture.ts
+++ b/src/support/fixture.ts
@@ -21,9 +21,9 @@ export const fixture = function (originalCommand: ((...args: any[]) => any), fix
         }
 
         // The project has no fixture of that name, so read the copy shipped with this library.
-        // This read takes the project's defaultCommandTimeout: a private budget of a few hundred
-        // milliseconds made it the first command to fail on a loaded machine, which turned a slow
-        // disk into a failed test. A failure here is not caught on purpose. cy.readFile() queues a
+        // This read takes the project's defaultCommandTimeout: a shorter budget of its own made it
+        // the first command to fail on a loaded machine, which turned a slow disk read into a
+        // failed test. A failure here is not caught on purpose. cy.readFile() queues a
         // command instead of running inline, so a try/catch around it never sees the error, and a
         // fixture the caller cannot read is a failure in every case.
         return cy.readFile(PACKAGED_FIXTURES_PATH + fixtureParam, encoding, {log: false});

--- a/tests/cypress/e2e/fixture.spec.ts
+++ b/tests/cypress/e2e/fixture.spec.ts
@@ -1,0 +1,44 @@
+/**
+ * Tests for the cy.fixture() override
+ *
+ * The override reads the fixture from the project first, and falls back to the copy shipped with
+ * this library when the project has none. These tests cover both paths, and the timeout the
+ * fallback read is given.
+ */
+
+import {fixture} from '../../../src/support/fixture';
+
+Cypress.Commands.overwrite('fixture', fixture);
+
+const FALLBACK_TIMEOUT = 1234;
+const MISSING_FIXTURE = 'groovy/thisFixtureExistsNowhere.groovy';
+
+describe('cy.fixture() override', () => {
+    it('reads a fixture from the project', () => {
+        cy.fixture('fixtureOverride.json').then(content => {
+            expect(content.source).to.equal('project');
+        });
+    });
+
+    it('reads a fixture from the project with an explicit encoding', () => {
+        cy.fixture('fixtureOverride.json', 'utf-8').then(content => {
+            expect(content).to.be.a('string');
+            expect(content).to.contain('project');
+        });
+    });
+
+    // The fallback read must take the project's defaultCommandTimeout. It used to carry a private
+    // budget of a few hundred milliseconds, which made it the first command to fail on a loaded
+    // machine, so a slow disk read failed the test that asked for the fixture.
+    describe('when the fixture is in neither place', {defaultCommandTimeout: FALLBACK_TIMEOUT}, () => {
+        it('fails on the fallback read, after the project defaultCommandTimeout', done => {
+            cy.on('fail', error => {
+                expect(error.message).to.contain('node_modules/@jahia/cypress/fixtures/' + MISSING_FIXTURE);
+                expect(error.message).to.contain(`${FALLBACK_TIMEOUT}ms`);
+                done();
+            });
+
+            cy.fixture(MISSING_FIXTURE);
+        });
+    });
+});

--- a/tests/cypress/fixtures/fixtureOverride.json
+++ b/tests/cypress/fixtures/fixtureOverride.json
@@ -1,0 +1,3 @@
+{
+    "source": "project"
+}


### PR DESCRIPTION
## Summary

`cy.fixture()` is overridden to read the project's own fixture first, and to fall back to the copy shipped with this library when the project has none. That fallback read carried a private timeout of 2000 ms. It now takes the project's `defaultCommandTimeout`, like every other command.

## Why

A test that resolves a fixture through the fallback could fail for no reason other than a slow disk read. The fallback read had a budget of 2000 ms while the rest of the suite had 10000 ms, so on a loaded CI machine it was the first command to time out. The failure was reported as `cy.readFile("./node_modules/@jahia/cypress/fixtures/...") timed out after waiting 2000ms`.

This is what makes it costly: `createSite` and `deleteSite` read their Groovy through `cy.fixture()`, and a project that has no `cypress/fixtures/groovy/admin/` of its own can only resolve them from the packaged copy. So every spec that creates or deletes a site is exposed, and the read most often happens in `before all` / `after all`. A timeout in a hook is reported by Cypress as the test failing, and the remaining tests of the spec are skipped. One slow read then costs a whole spec file. `Jahia/siteSettings` saw this on 11 of 20 specs in a single nightly run.

There was no reason for a private budget on a local file read. The timeout had already been raised four times, `0` to `200` to `500` to `1000` to `2000` (#28, #35, #57), each time without removing the cause.

The `try`/`catch` around the read is a second defect and is removed. `cy.readFile()` queues a command instead of running inline, so the `catch` could never see the error. It only suggested the failure was handled, while the timeout escaped as an unhandled command failure. Every caller of `cy.fixture()` in this library needs the content it asks for, so a fixture that resolves nowhere is a failure in every case, and it should read as one.

## Changes

* the fallback read inherits `defaultCommandTimeout` instead of a fixed 2000 ms
* the dead `try`/`catch` around it is gone, and the read is returned explicitly rather than relying on Cypress carrying the subject forward
* new self-test `tests/cypress/e2e/fixture.spec.ts`: the project path resolves with and without an explicit encoding, and a fixture that exists in neither place fails on the fallback read after the project's `defaultCommandTimeout`

## Validation

`yarn lint` and `yarn run build` pass. The full suite in `tests/` passes: `fixture.spec.ts` 3/3, `jfaker.spec.ts` 53/53, `modSince.spec.ts` 30 passing and 9 skipped.

The new timeout test was checked against the previous code, so it is a real regression test and not a test that would pass either way. With `timeout: 2000` restored it fails with `expected 'Timed out retrying after 2000ms: ...' to include '1234ms'`, where 1234 ms is the `defaultCommandTimeout` the suite sets.

A green run does not by itself prove the flake is gone, since it depends on timing. What is proved is that the read no longer carries a budget of its own, which is what made a slow disk read fail a test.

## Documentation

None needed.

## ADR

None.
