### PR TITLE
fix: fail fast when the test environment cannot start

### DIFF
--- a/.chachalog/Kq7bV2xR.md
+++ b/.chachalog/Kq7bV2xR.md
@@ -3,4 +3,4 @@
 "@jahia/cypress": patch
 ---
 
-Fixed CI startup so it fails immediately when an image cannot be pulled, instead of hanging until the job times out. The job log now shows the registry error instead of an unanswered confirmation prompt.
+Fixed CI startup so it fails immediately when an image cannot be pulled, instead of hanging until the job times out. The job log now shows the registry error instead of an unanswered confirmation prompt. (#243)

--- a/.chachalog/Kq7bV2xR.md
+++ b/.chachalog/Kq7bV2xR.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/cypress": patch
+---
+
+Fixed CI startup so it fails immediately when an image cannot be pulled, instead of hanging until the job times out. The job log now shows the registry error instead of an unanswered confirmation prompt.

--- a/ci.startup.sh
+++ b/ci.startup.sh
@@ -31,10 +31,19 @@ if [[ "${JAHIA_CLUSTER_ENABLED}" == "true" ||  ${JAHIA_CLUSTER_ENABLED} == true 
     export CLUSTER_PROFILE="--profile cluster"
 fi
 
+# Both docker-compose calls below read from /dev/null on purpose. docker-compose v1 answers an
+# unusable image (wrong name, wrong registry, missing docker login) with an interactive
+# confirmation prompt instead of an error. In CI nothing ever answers it, so the job hangs until
+# it times out. With stdin closed the prompt fails immediately and the real registry error is
+# reported, and the exit code is checked so the startup does not silently continue.
 echo "$(date +'%d %B %Y - %k:%M') == Starting environment =="
-docker-compose ${CLUSTER_PROFILE} up -d --renew-anon-volumes $(docker-compose config --services | grep -v "cypress")
+if ! docker-compose ${CLUSTER_PROFILE} up -d --renew-anon-volumes $(docker-compose config --services | grep -v "cypress") < /dev/null; then
+    echo "$(date +'%d %B %Y - %k:%M') == STARTUP FAILURE, unable to start the environment. Check the image names, the registry and the docker login above =="
+    exit 1
+fi
+
 if [[ "$1" != "notests" ]]; then
     docker ps -a
     docker stats --no-stream
-    docker-compose up --abort-on-container-exit cypress
+    docker-compose up --abort-on-container-exit cypress < /dev/null
 fi


### PR DESCRIPTION
## Summary

`ci.startup.sh` now stops as soon as the test environment cannot start, instead of letting the CI job hang until its timeout.

## Why

`docker-compose` v1 (v1.29.2 is what `Jahia/jahia-modules-action` installs for integration tests) does not report an unusable image as an error. Any image it cannot pull — wrong name, wrong registry, no `docker login` — surfaces as `ImageNotFound`, which `docker-compose up` catches and turns into an interactive question:

```
The image for the service you're trying to recreate has been removed. If you continue, volume data could be lost. Consider backing up your data before continuing.

Continue with the new image? [yN]
```

The message is misleading (nothing was removed, no volume is at risk) and the question is read from stdin, which nothing answers in GitHub Actions. The job then sits at that prompt until its timeout, and someone has to cancel and retrigger it. A recent example is [jahia-csrf-guard#190](https://github.com/Jahia/jahia-csrf-guard/pull/190), where [the job](https://github.com/Jahia/jahia-csrf-guard/actions/runs/32141361884/job/95725854196) waited 20 minutes at that prompt while the real problem, `pull access denied for jahia/jahia-ee-dev`, had already been logged six minutes earlier.

Closing stdin is what makes this robust: it does not depend on which failure produced the prompt, or on the compose version in use.

The CI-side fixes — moving the integration tests off the end-of-life `docker-compose` 1.29.2, and failing the job as soon as `jahia_image` cannot be pulled — are tracked separately in [jahia-modules-action#401](https://github.com/Jahia/jahia-modules-action/issues/401).

## Changes

* Both `docker-compose` calls read from `/dev/null`, so a prompt cannot block the job.
* The exit code of the startup `up` is checked. On failure the script reports `STARTUP FAILURE, unable to start the environment` and exits 1, so the run does not continue to the tests with no environment.
* A comment records why stdin is closed, so the redirection is not removed as noise later.

A healthy run is unaffected.

## Validation

Reproduced the failure and verified the fix with `docker/compose:1.29.2` against a compose file whose image cannot be pulled, calling the startup block with its caller's stdin held open the way `@actions/exec` holds it in Actions:

* before: no further output, the process stays at `Continue with the new image? [yN]` for as long as the caller waits (killed at the timeout, exit 124).
* after: exit 1 within seconds, printing `pull access denied for ... repository does not exist or may require 'docker login'` followed by `== STARTUP FAILURE, unable to start the environment ... ==`.

`bash -n ci.startup.sh` passes.

## Documentation

None needed.

## ADR

None.
